### PR TITLE
fix: keep README quick start runnable and tidy parse_request example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: just typecheck
       - name: Lint
         run: just lint
+      - name: Check README quick-start snippet matches example
+        run: just check-readme
 
   build-and-test:
     name: Build and test (${{ matrix.target }})

--- a/README.md
+++ b/README.md
@@ -34,27 +34,35 @@ gleam add gleam_yielder
 
 ## Quick start
 
+The snippet below is the source of `examples/quick_start` verbatim;
+copy it into `src/main.gleam`, run `gleam add multipartkit`, then
+`gleam run`.
+
 ```gleam
-import gleam/option.{Some}
-import gleeunit/should
+import gleam/io
+import gleam/option.{None, Some}
 import multipartkit
 import multipartkit/form
 import multipartkit/query
 
-pub fn round_trip_test() {
+pub fn main() {
   let request_form =
     form.new()
     |> form.add_field("title", "hello")
     |> form.add_file("avatar", "cat.png", "image/png", <<137, 80, 78, 71>>)
 
   let #(content_type, body) = multipartkit.encode_form(request_form)
+
   let assert Ok(parts) = multipartkit.parse(body, content_type)
-
-  query.required_field(parts, "title")
-  |> should.equal(Ok("hello"))
-
+  let assert Ok(title) = query.required_field(parts, "title")
   let assert Ok(avatar) = query.required_file(parts, "avatar")
-  avatar.filename |> should.equal(Some("cat.png"))
+
+  io.println("Content-Type: " <> content_type)
+  io.println("title=" <> title)
+  case avatar.filename {
+    Some(filename) -> io.println("avatar filename=" <> filename)
+    None -> io.println("avatar has no filename")
+  }
 }
 ```
 

--- a/examples/parse_request/src/multipartkit_parse_request.gleam
+++ b/examples/parse_request/src/multipartkit_parse_request.gleam
@@ -10,6 +10,7 @@ import gleam/bit_array
 import gleam/int
 import gleam/io
 import gleam/option.{None, Some}
+import gleam/result
 import multipartkit
 import multipartkit/error.{
   type MultipartError, BodyTooLarge, DisallowedContentType, HeaderTooLarge,
@@ -43,7 +44,7 @@ pub fn main() {
 
 /// Decode an `Upload` from the raw body and content-type produced by an
 /// HTTP framework. Demonstrates how `parse_with_limits`, `query.required_*`,
-/// and `validate` compose into a tidy request pipeline.
+/// and `validate` compose into a tidy `use <- result.try` pipeline.
 pub fn parse_upload(
   body: BitArray,
   content_type: String,
@@ -56,43 +57,17 @@ pub fn parse_upload(
       max_parts: 10,
       max_header_bytes: 8_192,
     )
-  case multipartkit.parse_with_limits(body, content_type, limits) {
-    Error(err) -> Error(err)
-    Ok(parts) -> finalise_upload(parts)
-  }
-}
-
-fn finalise_upload(parts: List(Part)) -> Result(Upload, MultipartError) {
-  case query.required_field(parts, "title") {
-    Error(err) -> Error(err)
-    Ok(title) ->
-      case query.required_field(parts, "notes") {
-        Error(err) -> Error(err)
-        Ok(notes) ->
-          case query.required_file(parts, "avatar") {
-            Error(err) -> Error(err)
-            Ok(avatar) -> validate_avatar(avatar, title, notes)
-          }
-      }
-  }
-}
-
-fn validate_avatar(
-  avatar: Part,
-  title: String,
-  notes: String,
-) -> Result(Upload, MultipartError) {
-  case validate.max_file_size(avatar, 50_000) {
-    Error(err) -> Error(err)
-    Ok(avatar) ->
-      case
-        validate.allowed_content_types(avatar, ["image/png", "image/jpeg"])
-      {
-        Error(err) -> Error(err)
-        Ok(avatar) ->
-          Ok(Upload(title: title, notes: notes, avatar: avatar))
-      }
-  }
+  use parts <- result.try(
+    multipartkit.parse_with_limits(body, content_type, limits),
+  )
+  use title <- result.try(query.required_field(parts, "title"))
+  use notes <- result.try(query.required_field(parts, "notes"))
+  use avatar <- result.try(query.required_file(parts, "avatar"))
+  use avatar <- result.try(validate.max_file_size(avatar, 50_000))
+  use avatar <- result.try(validate.allowed_content_types(avatar, [
+    "image/png", "image/jpeg",
+  ]))
+  Ok(Upload(title: title, notes: notes, avatar: avatar))
 }
 
 fn sample_body() -> BitArray {

--- a/examples/quick_start/src/multipartkit_quick_start.gleam
+++ b/examples/quick_start/src/multipartkit_quick_start.gleam
@@ -1,11 +1,3 @@
-//// Quick-start example for `multipartkit`.
-////
-//// Build a `multipart/form-data` body, encode it with a freshly generated
-//// boundary, and parse it back. Run with:
-////
-////    cd examples/quick_start
-////    gleam run
-
 import gleam/io
 import gleam/option.{None, Some}
 import multipartkit

--- a/justfile
+++ b/justfile
@@ -54,6 +54,12 @@ check: clean
   gleam run -m glinter
   gleam build --warnings-as-errors
   gleam test
+  just check-readme
+
+# Verify that the first ```gleam``` snippet in README.md still matches
+# examples/quick_start (the source of truth for the quick-start code).
+check-readme:
+  sh scripts/check_readme_snippet.sh
 
 ci: deps check build-javascript test-javascript examples
 

--- a/scripts/check_readme_snippet.sh
+++ b/scripts/check_readme_snippet.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# check_readme_snippet.sh -- Verify that the first ```gleam code block in
+# README.md matches the canonical quick-start example file
+# byte-for-byte. Catches doc/example drift in CI.
+
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+README="$ROOT/README.md"
+EXAMPLE="$ROOT/examples/quick_start/src/multipartkit_quick_start.gleam"
+
+if [ ! -f "$README" ]; then
+  echo "error: README.md not found at $README" >&2
+  exit 1
+fi
+if [ ! -f "$EXAMPLE" ]; then
+  echo "error: quick-start example not found at $EXAMPLE" >&2
+  exit 1
+fi
+
+EXTRACTED="$(mktemp)"
+trap 'rm -f "$EXTRACTED"' EXIT
+
+awk '
+  BEGIN { capture = 0; done = 0 }
+  /^```gleam$/ && !done { capture = 1; next }
+  /^```$/ && capture { done = 1; capture = 0; exit }
+  capture { print }
+' "$README" > "$EXTRACTED"
+
+if ! diff -u "$EXAMPLE" "$EXTRACTED"; then
+  cat <<EOF >&2
+
+error: the first \`\`\`gleam\`\`\` block in README.md drifted from
+$EXAMPLE.
+
+Update one of them so that they match. The example file is the source
+of truth: it is built and run on every CI push.
+EOF
+  exit 1
+fi
+
+echo "README quick-start snippet matches $EXAMPLE"

--- a/scripts/check_readme_snippet.sh
+++ b/scripts/check_readme_snippet.sh
@@ -28,6 +28,11 @@ awk '
   capture { print }
 ' "$README" > "$EXTRACTED"
 
+if [ ! -s "$EXTRACTED" ]; then
+  echo "error: README.md does not contain a non-empty first \`\`\`gleam\`\`\` block" >&2
+  exit 1
+fi
+
 if ! diff -u "$EXAMPLE" "$EXTRACTED"; then
   cat <<EOF >&2
 


### PR DESCRIPTION
## Summary

- Rewrite the README "Quick start" snippet so a brand-new user can copy it into `src/main.gleam` and run `gleam run` after a single `gleam add multipartkit`. The previous example imported `gleeunit` and used a `_test` function — fresh projects don't have gleeunit at build time.
- Refactor `examples/parse_request/parse_upload` to use `use <- result.try` instead of nested `case` chains. The pipeline now reads like idiomatic Gleam.
- Pin the README quick-start snippet to the canonical example file. A new `scripts/check_readme_snippet.sh` (wired into the `check-readme` just recipe and a CI job step) diffs the first \`\`\`gleam\`\`\` block in README.md against `examples/quick_start/src/multipartkit_quick_start.gleam`. Fails CI if they drift.

Addresses the review findings:

- Medium: README quick start was not copy-paste runnable.
- Low: `parse_request` example used nested `case` instead of `result.try`.
- Low: README snippets were not pinned by CI.

## Test plan

- [x] \`just check\` (format / lint / type-check / build / test / check-readme) passes locally
- [x] \`just examples\` (4 example projects) passes locally
- [x] \`scripts/check_readme_snippet.sh\` matches README and example
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised quick-start example from test-style to a fully runnable program, demonstrating practical usage with output for Content-Type, title, and avatar handling.

* **Refactor**
  * Streamlined request parsing example using a linear pipeline approach to eliminate nested conditionals for improved readability.

* **Chores**
  * Added automated CI validation to ensure documentation examples remain synchronized with their source implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->