### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-29
+
+First public release.
+
 ### Added
 
 - Project scaffold: Gleam package metadata, cross-target CI workflows,
@@ -33,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - `multipartkit/limit` — `Limits` and `default_limits`
   - `multipartkit/infer` — pluggable `Inferer` (default `None`); wire
     `nao1215/mimetype` or another inferer via `add_file_auto_with`
-- 133 unit tests passing on both Erlang/BEAM and JavaScript targets.
+- 136 unit tests passing on both Erlang/BEAM and JavaScript targets.
 
 ### Security
 
@@ -47,9 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
-- Added four runnable examples under `examples/` — `quick_start`,
+- Four runnable examples under `examples/` — `quick_start`,
   `parse_request`, `streaming_parse`, and `mimetype_inference`. The
   `just examples` recipe builds and runs them all under
   `--warnings-as-errors`; CI runs the same recipe on every push.
-- README rewritten as a user-facing front door (badges, install,
-  quick-start, examples table, streaming caveat).
+- README written as a user-facing front door: badges, install,
+  quick-start, examples table, and an explicit streaming caveat for
+  v0.1.0. The README quick-start snippet is pinned to the
+  `examples/quick_start` source via `scripts/check_readme_snippet.sh`,
+  enforced by CI.
+
+[0.1.0]: https://github.com/nao1215/multipartkit/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Promote the `Unreleased` CHANGELOG entry to a `[0.1.0] - 2026-04-29` section so the release workflow can extract it when the `v0.1.0` tag is pushed.

- Move `Unreleased` content under `## [0.1.0] - 2026-04-29` heading.
- Bump test count to 136 (current passing total on both targets).
- Add a Documentation note about the new CI-pinned README snippet (introduced in #2).
- Add the `[0.1.0]` reference link footer.

`gleam.toml` already declares `version = "0.1.0"`, so no version bump is needed there.

## After merge

Push tag `v0.1.0` to trigger `.github/workflows/release.yml`:

```sh
git checkout main && git pull
git tag v0.1.0
git push origin v0.1.0
```

The workflow will run the full test matrix on both targets, publish to Hex, and create a GitHub release with the changelog body extracted from the new section.

## Test plan

- [x] \`just check\` passes locally
- [x] Release workflow's changelog-extraction \`awk\` correctly captures the new section (heading format \`## [0.1.0] - 2026-04-29\` matches the pattern \`^#{2,3} \\[?0.1.0\\]?\`)
- [ ] CI green on this PR