### PR TITLE
feat(limit): add validated Limits builder and accessors (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **limit**: validated `Limits` builder `limit.new(...)` returns
+  `Result(Limits, LimitConfigError)` and rejects non-positive values
+  through the `NonPositiveLimit(field:, given:)` variant. Field
+  accessor functions (`max_body_bytes`, `max_part_bytes`, `max_parts`,
+  `max_header_bytes`) provide a stable inspection surface ahead of
+  the `Limits` type being closed. The top-level facade re-exports
+  the type and builder as `multipartkit.LimitConfigError` and
+  `multipartkit.new_limits`. Direct `Limits(...)` construction stays
+  available so this is non-breaking, but the runnable examples now
+  use the validated builder. (#10)
+
 ## [0.2.0] - 2026-04-29
 
 ### Fixed

--- a/examples/parse_request/src/multipartkit_parse_request.gleam
+++ b/examples/parse_request/src/multipartkit_parse_request.gleam
@@ -16,7 +16,7 @@ import multipartkit/error.{
   type MultipartError, BodyTooLarge, DisallowedContentType, HeaderTooLarge,
   InvalidUtf8Field, MissingField, MissingFile, PartTooLarge, TooManyParts,
 }
-import multipartkit/limit.{Limits}
+import multipartkit/limit
 import multipartkit/part.{type Part}
 import multipartkit/query
 import multipartkit/validate
@@ -50,33 +50,36 @@ pub fn parse_upload(
   content_type: String,
 ) -> Result(Upload, MultipartError) {
   // Tighter limits than `default_limits()` for a public endpoint.
-  let limits =
-    Limits(
+  // The values are hard-coded so the validated `new` is known to
+  // succeed; production code with dynamic values should propagate
+  // `LimitConfigError` through the result chain.
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 1_000_000,
       max_part_bytes: 200_000,
       max_parts: 10,
-      max_header_bytes: 8_192,
+      max_header_bytes: 8192,
     )
-  use parts <- result.try(
-    multipartkit.parse_with_limits(body, content_type, limits),
-  )
+  use parts <- result.try(multipartkit.parse_with_limits(
+    body,
+    content_type,
+    limits,
+  ))
   use title <- result.try(query.required_field(parts, "title"))
   use notes <- result.try(query.required_field(parts, "notes"))
   use avatar <- result.try(query.required_file(parts, "avatar"))
   use avatar <- result.try(validate.max_file_size(avatar, 50_000))
-  use avatar <- result.try(validate.allowed_content_types(avatar, [
-    "image/png", "image/jpeg",
-  ]))
+  use avatar <- result.try(
+    validate.allowed_content_types(avatar, ["image/png", "image/jpeg"]),
+  )
   Ok(Upload(title: title, notes: notes, avatar: avatar))
 }
 
 fn sample_body() -> BitArray {
-  let dash = bit_array.from_string(
-    "------WebKitFormBoundary7MA4YWxkTrZu0gW\r\n",
-  )
-  let close = bit_array.from_string(
-    "------WebKitFormBoundary7MA4YWxkTrZu0gW--\r\n",
-  )
+  let dash =
+    bit_array.from_string("------WebKitFormBoundary7MA4YWxkTrZu0gW\r\n")
+  let close =
+    bit_array.from_string("------WebKitFormBoundary7MA4YWxkTrZu0gW--\r\n")
   bit_array.concat([
     dash,
     <<"Content-Disposition: form-data; name=\"title\"\r\n\r\n":utf8>>,

--- a/examples/streaming_parse/src/multipartkit_streaming_parse.gleam
+++ b/examples/streaming_parse/src/multipartkit_streaming_parse.gleam
@@ -18,7 +18,7 @@ import gleam/option.{None, Some}
 import gleam/yielder
 import multipartkit
 import multipartkit/error.{type MultipartError, BodyTooLarge}
-import multipartkit/limit.{Limits}
+import multipartkit/limit
 import multipartkit/stream
 
 pub fn main() {
@@ -50,8 +50,7 @@ fn run_happy() -> Result(Nil, MultipartError) {
       yielder.each(parts_yielder, fn(item) {
         case item {
           Ok(stream_part) -> describe_part(stream_part)
-          Error(_) ->
-            io.println("error item — iterator is now exhausted")
+          Error(_) -> io.println("error item — iterator is now exhausted")
         }
       })
       Ok(Nil)
@@ -74,9 +73,7 @@ fn describe_body(body: BitArray) -> String {
   case bit_array.to_string(body) {
     Ok(text) -> "text: " <> text
     Error(_) ->
-      "binary, "
-      <> int.to_string(bit_array.byte_size(body))
-      <> " bytes"
+      "binary, " <> int.to_string(bit_array.byte_size(body)) <> " bytes"
   }
 }
 
@@ -84,10 +81,9 @@ fn run_oversized() -> Nil {
   let big_first_chunk = <<
     "--B\r\nContent-Disposition: form-data; name=\"big\"\r\n\r\nAAAAAAAAAAAAAAAAAAAA":utf8,
   >>
-  let chunks =
-    yielder.from_list([big_first_chunk, <<"\r\n--B--\r\n":utf8>>])
-  let limits =
-    Limits(
+  let chunks = yielder.from_list([big_first_chunk, <<"\r\n--B--\r\n":utf8>>])
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 30,
       max_part_bytes: 1000,
       max_parts: 100,
@@ -103,8 +99,8 @@ fn run_oversized() -> Nil {
     yielder.Next(Error(BodyTooLarge(limit_value)), _) ->
       io.println(
         "rejected after pulling chunk 1: BodyTooLarge("
-          <> int.to_string(limit_value)
-          <> ")",
+        <> int.to_string(limit_value)
+        <> ")",
       )
     _ -> io.println("(unexpected outcome)")
   }

--- a/src/multipartkit.gleam
+++ b/src/multipartkit.gleam
@@ -31,6 +31,10 @@ pub type Form =
 pub type Limits =
   limit.Limits
 
+/// Re-export of `multipartkit/limit.LimitConfigError`.
+pub type LimitConfigError =
+  limit.LimitConfigError
+
 /// Re-export of `multipartkit/error.MultipartError`.
 pub type MultipartError =
   error.MultipartError
@@ -94,4 +98,21 @@ pub fn encode_stream(
 /// Re-export of `multipartkit/limit.default_limits`.
 pub fn default_limits() -> Limits {
   limit.default_limits()
+}
+
+/// Re-export of `multipartkit/limit.new`. Construct a validated
+/// `Limits` value; non-positive fields surface as
+/// `LimitConfigError.NonPositiveLimit`.
+pub fn new_limits(
+  max_body_bytes max_body_bytes: Int,
+  max_part_bytes max_part_bytes: Int,
+  max_parts max_parts: Int,
+  max_header_bytes max_header_bytes: Int,
+) -> Result(Limits, LimitConfigError) {
+  limit.new(
+    max_body_bytes: max_body_bytes,
+    max_part_bytes: max_part_bytes,
+    max_parts: max_parts,
+    max_header_bytes: max_header_bytes,
+  )
 }

--- a/src/multipartkit/limit.gleam
+++ b/src/multipartkit/limit.gleam
@@ -1,3 +1,4 @@
+import gleam/bool
 import gleam/result
 
 /// Limits applied during parsing to bound resource consumption.
@@ -89,10 +90,11 @@ pub fn new(
 }
 
 fn check_positive(field: String, value: Int) -> Result(Nil, LimitConfigError) {
-  case value < 1 {
-    True -> Error(NonPositiveLimit(field: field, given: value))
-    False -> Ok(Nil)
-  }
+  use <- bool.guard(
+    value < 1,
+    Error(NonPositiveLimit(field: field, given: value)),
+  )
+  Ok(Nil)
 }
 
 /// Total-input byte budget. See `Limits.max_body_bytes`.

--- a/src/multipartkit/limit.gleam
+++ b/src/multipartkit/limit.gleam
@@ -1,7 +1,14 @@
+import gleam/result
+
 /// Limits applied during parsing to bound resource consumption.
 ///
 /// All limits are inclusive: a value equal to the limit is allowed; the
 /// `(limit + 1)`-th byte / part triggers the error.
+///
+/// Construct via `new` (validated, recommended) or `default` (conservative
+/// presets). Direct `Limits(...)` construction stays available for
+/// trusted callers, but `new` is the supported path for any value sourced
+/// from configuration, request input, or other dynamic input.
 pub type Limits {
   Limits(
     /// Total bytes consumed from input, including boundary delimiters,
@@ -21,6 +28,16 @@ pub type Limits {
   )
 }
 
+/// Why a `Limits` value could not be constructed.
+///
+/// Returned by `new` when a field receives a non-positive value.
+/// `field` names the offending field so a single handler can produce a
+/// meaningful error message even when several limits are misconfigured
+/// at once (the first failing field stops further checks).
+pub type LimitConfigError {
+  NonPositiveLimit(field: String, given: Int)
+}
+
 /// Conservative defaults used by `parse` and `parse_stream` when no explicit
 /// limits are supplied.
 pub fn default_limits() -> Limits {
@@ -30,4 +47,70 @@ pub fn default_limits() -> Limits {
     max_parts: 100,
     max_header_bytes: 16_384,
   )
+}
+
+/// Construct a `Limits` value with validation. Each field must be `>= 1`;
+/// otherwise the returned `Error` names the first failing field.
+///
+/// Use this in any path where the limit values come from configuration,
+/// CLI flags, request input, or other dynamic input. For trusted
+/// constants the direct `Limits(...)` constructor is also fine, but
+/// callers that want a stable surface ahead of the `Limits` type being
+/// closed (see the upcoming opaque-type work) should prefer `new`.
+///
+/// Example:
+///   import multipartkit/limit
+///
+///   case limit.new(
+///     max_body_bytes: 5_000_000,
+///     max_part_bytes: 2_000_000,
+///     max_parts: 50,
+///     max_header_bytes: 8_192,
+///   ) {
+///     Ok(limits) -> ...
+///     Error(limit.NonPositiveLimit(field: f, given: g)) -> ...
+///   }
+pub fn new(
+  max_body_bytes max_body_bytes: Int,
+  max_part_bytes max_part_bytes: Int,
+  max_parts max_parts: Int,
+  max_header_bytes max_header_bytes: Int,
+) -> Result(Limits, LimitConfigError) {
+  use _ <- result.try(check_positive("max_body_bytes", max_body_bytes))
+  use _ <- result.try(check_positive("max_part_bytes", max_part_bytes))
+  use _ <- result.try(check_positive("max_parts", max_parts))
+  use _ <- result.try(check_positive("max_header_bytes", max_header_bytes))
+  Ok(Limits(
+    max_body_bytes: max_body_bytes,
+    max_part_bytes: max_part_bytes,
+    max_parts: max_parts,
+    max_header_bytes: max_header_bytes,
+  ))
+}
+
+fn check_positive(field: String, value: Int) -> Result(Nil, LimitConfigError) {
+  case value < 1 {
+    True -> Error(NonPositiveLimit(field: field, given: value))
+    False -> Ok(Nil)
+  }
+}
+
+/// Total-input byte budget. See `Limits.max_body_bytes`.
+pub fn max_body_bytes(limits: Limits) -> Int {
+  limits.max_body_bytes
+}
+
+/// Per-part body byte budget. See `Limits.max_part_bytes`.
+pub fn max_part_bytes(limits: Limits) -> Int {
+  limits.max_part_bytes
+}
+
+/// Maximum number of parts. See `Limits.max_parts`.
+pub fn max_parts(limits: Limits) -> Int {
+  limits.max_parts
+}
+
+/// Per-part header-block byte budget. See `Limits.max_header_bytes`.
+pub fn max_header_bytes(limits: Limits) -> Int {
+  limits.max_header_bytes
 }

--- a/test/multipartkit/limit_test.gleam
+++ b/test/multipartkit/limit_test.gleam
@@ -1,0 +1,93 @@
+import gleeunit/should
+import multipartkit/limit
+
+pub fn new_ok_returns_limits_test() {
+  let assert Ok(l) =
+    limit.new(
+      max_body_bytes: 1000,
+      max_part_bytes: 500,
+      max_parts: 5,
+      max_header_bytes: 256,
+    )
+  l |> limit.max_body_bytes |> should.equal(1000)
+  l |> limit.max_part_bytes |> should.equal(500)
+  l |> limit.max_parts |> should.equal(5)
+  l |> limit.max_header_bytes |> should.equal(256)
+}
+
+pub fn new_rejects_zero_max_body_bytes_test() {
+  case
+    limit.new(
+      max_body_bytes: 0,
+      max_part_bytes: 500,
+      max_parts: 5,
+      max_header_bytes: 256,
+    )
+  {
+    Error(limit.NonPositiveLimit(field: f, given: g)) -> {
+      f |> should.equal("max_body_bytes")
+      g |> should.equal(0)
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn new_rejects_negative_max_part_bytes_test() {
+  case
+    limit.new(
+      max_body_bytes: 1000,
+      max_part_bytes: -1,
+      max_parts: 5,
+      max_header_bytes: 256,
+    )
+  {
+    Error(limit.NonPositiveLimit(field: f, given: g)) -> {
+      f |> should.equal("max_part_bytes")
+      g |> should.equal(-1)
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn new_rejects_zero_max_parts_test() {
+  case
+    limit.new(
+      max_body_bytes: 1000,
+      max_part_bytes: 500,
+      max_parts: 0,
+      max_header_bytes: 256,
+    )
+  {
+    Error(limit.NonPositiveLimit(field: f, given: _)) ->
+      f |> should.equal("max_parts")
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn new_rejects_zero_max_header_bytes_test() {
+  case
+    limit.new(
+      max_body_bytes: 1000,
+      max_part_bytes: 500,
+      max_parts: 5,
+      max_header_bytes: 0,
+    )
+  {
+    Error(limit.NonPositiveLimit(field: f, given: _)) ->
+      f |> should.equal("max_header_bytes")
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn default_limits_passes_validation_test() {
+  let d = limit.default_limits()
+  let assert Ok(l) =
+    limit.new(
+      max_body_bytes: limit.max_body_bytes(d),
+      max_part_bytes: limit.max_part_bytes(d),
+      max_parts: limit.max_parts(d),
+      max_header_bytes: limit.max_header_bytes(d),
+    )
+  limit.max_body_bytes(l)
+  |> should.equal(limit.max_body_bytes(d))
+}


### PR DESCRIPTION
## Summary

Add a validated `Limits` builder so callers don't need to spell the raw constructor when sourcing limit values from configuration or request input. Complements the upcoming opaque-type work by giving users a stable construction surface ahead of `Limits` being closed.

## Changes

- `src/multipartkit/limit.gleam`
  - new `LimitConfigError` public type with a `NonPositiveLimit(field:, given:)` variant
  - new `limit.new(...)` validated builder returning `Result(Limits, LimitConfigError)`
  - new field accessors: `max_body_bytes`, `max_part_bytes`, `max_parts`, `max_header_bytes`
- `src/multipartkit.gleam` — re-export `LimitConfigError` and `new_limits` at the facade.
- `test/multipartkit/limit_test.gleam` — coverage for Ok / per-field error paths and accessors.
- `examples/parse_request`, `examples/streaming_parse` — migrate to `limit.new`.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Design Decisions

- Kept the existing `Limits(...)` constructor exported. This change is purely additive so it can ship before the broader opaque-type work in #8 without breaking downstream callers.
- Validation is `value < 1`. All four fields semantically count something (bytes / parts) and zero is never a useful production setting; rejecting non-positives is the smallest defensible rule for the dynamic-input path.
- Stop-at-first-error rather than batching field errors. The error variant carries `field: String` so the call site can produce a meaningful message; reporting all four invalid fields at once would require a separate batched-error type that is overkill for this surface.
- Did not touch the parser/stream tests that build `Limits` directly — they use trusted constants and the direct constructor remains the right tool for those call sites.

Closes #10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a validated builder for configuring limits that validates input values and rejects non-positive entries.
  * Added error type to surface validation errors with field-level details.
  * Added accessor functions to retrieve individual limit values from configurations.

* **Tests**
  * Added validation tests for the limits builder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->