### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-30
+
 ### Added
 
 - **limit**: validated `Limits` builder `limit.new(...)` returns

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.2.0"
+version = "0.3.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Added

- **limit**: validated `Limits` builder `limit.new(...)` returns
  `Result(Limits, LimitConfigError)` and rejects non-positive values
  through the `NonPositiveLimit(field:, given:)` variant. Field
  accessor functions (`max_body_bytes`, `max_part_bytes`, `max_parts`,
  `max_header_bytes`) provide a stable inspection surface ahead of
  the `Limits` type being closed. The top-level facade re-exports
  the type and builder as `multipartkit.LimitConfigError` and
  `multipartkit.new_limits`. Direct `Limits(...)` construction stays
  available so this is non-breaking, but the runnable examples now
  use the validated builder. (#10)
