### PR TITLE
refactor!: opaque-ify public multipart value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`Limits`, `Part`, `StreamPart`, and `ContentDisposition` are now
+  `pub opaque type` (BREAKING)**. Direct constructor calls
+  (`Limits(...)`, `Part(...)`, `StreamPart(...)`,
+  `ContentDisposition(...)`) and field-access expressions
+  (`limits.max_body_bytes`, `the_part.body`, `parsed.disposition`,
+  etc.) no longer compile from outside the defining module. The
+  representation can now evolve without breaking external pattern
+  matches. Migration paths:
+
+  - `Limits` — construct with `limit.new(max_body_bytes:,
+    max_part_bytes:, max_parts:, max_header_bytes:)` (returns
+    `Result(Limits, LimitConfigError)`) or `limit.default_limits()`.
+    Read fields via the `limit.max_body_bytes/1`,
+    `limit.max_part_bytes/1`, `limit.max_parts/1`, and
+    `limit.max_header_bytes/1` accessors that already shipped in
+    v0.3.0.
+  - `Part` — construct with `part.new(headers:, name:, filename:,
+    content_type:, body:)`. Read fields via `part.all_headers/1`,
+    `part.name/1`, `part.filename/1`, `part.content_type/1`, and
+    `part.body/1`. The existing `part.header/2` and `part.headers/2`
+    case-insensitive header lookups are unchanged.
+  - `StreamPart` — receive from `stream.parse_stream` /
+    `stream.from_part`; inspect via `stream.all_headers/1`,
+    `stream.name/1`, `stream.filename/1`, `stream.content_type/1`,
+    and `stream.body/1`.
+  - `ContentDisposition` — receive from
+    `content_disposition.parse/1`; inspect via
+    `content_disposition.disposition/1`,
+    `content_disposition.name/1`, `content_disposition.filename/1`,
+    and `content_disposition.params/1`.
+
+  README and examples are updated to use the accessors. (#8)
+
 ## [0.3.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ import gleam/io
 import gleam/option.{None, Some}
 import multipartkit
 import multipartkit/form
+import multipartkit/part
 import multipartkit/query
 
 pub fn main() {
@@ -59,7 +60,7 @@ pub fn main() {
 
   io.println("Content-Type: " <> content_type)
   io.println("title=" <> title)
-  case avatar.filename {
+  case part.filename(avatar) {
     Some(filename) -> io.println("avatar filename=" <> filename)
     None -> io.println("avatar has no filename")
   }

--- a/examples/mimetype_inference/src/multipartkit_mimetype_inference.gleam
+++ b/examples/mimetype_inference/src/multipartkit_mimetype_inference.gleam
@@ -74,15 +74,15 @@ pub fn add_file_auto_with_mimetype(
 }
 
 fn describe_part(the_part: part.Part) -> Nil {
-  let name = case the_part.name {
+  let name = case part.name(the_part) {
     Some(value) -> value
     None -> "(none)"
   }
-  let filename = case the_part.filename {
+  let filename = case part.filename(the_part) {
     Some(value) -> value
     None -> "(none)"
   }
-  let content_type = case the_part.content_type {
+  let content_type = case part.content_type(the_part) {
     Some(value) -> value
     None -> "(none)"
   }

--- a/examples/parse_request/src/multipartkit_parse_request.gleam
+++ b/examples/parse_request/src/multipartkit_parse_request.gleam
@@ -98,8 +98,8 @@ fn sample_body() -> BitArray {
 }
 
 fn avatar_summary(avatar: Part) -> String {
-  let size = bit_array.byte_size(avatar.body)
-  let filename = case avatar.filename {
+  let size = bit_array.byte_size(part.body(avatar))
+  let filename = case part.filename(avatar) {
     Some(value) -> value
     None -> "(none)"
   }

--- a/examples/quick_start/src/multipartkit_quick_start.gleam
+++ b/examples/quick_start/src/multipartkit_quick_start.gleam
@@ -2,6 +2,7 @@ import gleam/io
 import gleam/option.{None, Some}
 import multipartkit
 import multipartkit/form
+import multipartkit/part
 import multipartkit/query
 
 pub fn main() {
@@ -18,7 +19,7 @@ pub fn main() {
 
   io.println("Content-Type: " <> content_type)
   io.println("title=" <> title)
-  case avatar.filename {
+  case part.filename(avatar) {
     Some(filename) -> io.println("avatar filename=" <> filename)
     None -> io.println("avatar has no filename")
   }

--- a/examples/streaming_parse/src/multipartkit_streaming_parse.gleam
+++ b/examples/streaming_parse/src/multipartkit_streaming_parse.gleam
@@ -59,11 +59,11 @@ fn run_happy() -> Result(Nil, MultipartError) {
 }
 
 fn describe_part(stream_part: stream.StreamPart) -> Nil {
-  let label = case stream_part.name {
+  let label = case stream.name(stream_part) {
     Some(name) -> name
     None -> "(no name)"
   }
-  case stream.drain_body(stream_part.body) {
+  case stream.drain_body(stream.body(stream_part)) {
     Ok(body) -> io.println("- " <> label <> " — " <> describe_body(body))
     Error(_) -> io.println("- " <> label <> " (body errored)")
   }

--- a/src/multipartkit/content_disposition.gleam
+++ b/src/multipartkit/content_disposition.gleam
@@ -8,25 +8,52 @@ import multipartkit/internal/text
 
 /// A parsed `Content-Disposition` header value.
 ///
-/// `disposition` is lowercased (`"form-data"`, `"attachment"`, ...).
+/// Opaque — inspect through `disposition/1`, `name/1`, `filename/1`, and
+/// `params/1`. The internal layout may grow more fields (a parsed
+/// `creation-date`, etc.) without breaking external pattern matches.
 ///
-/// `name` and `filename` are convenience accessors decoded from RFC 5987 /
-/// RFC 8187 `*`-form when present (with the `*`-form taking precedence over
-/// the plain form), otherwise from the plain parameter value with surrounding
-/// quotes removed and backslash-escapes resolved per RFC 7230 quoted-string
-/// rules.
+/// Semantics of each accessor:
 ///
-/// `params` contains every parameter as it appeared in the input including
-/// `filename` and `name`, in order. Duplicate parameter names are preserved
-/// left-to-right; only the first occurrence wins for the convenience
-/// `name`/`filename` fields.
-pub type ContentDisposition {
+/// - `disposition/1` is lowercased (`"form-data"`, `"attachment"`, ...).
+/// - `name/1` and `filename/1` are convenience accessors decoded from
+///   RFC 5987 / RFC 8187 `*`-form when present (with the `*`-form taking
+///   precedence over the plain form), otherwise from the plain parameter
+///   value with surrounding quotes removed and backslash-escapes resolved
+///   per RFC 7230 quoted-string rules.
+/// - `params/1` contains every parameter as it appeared in the input
+///   including `filename` and `name`, in order. Duplicate parameter names
+///   are preserved left-to-right; only the first occurrence wins for the
+///   convenience `name`/`filename` fields.
+pub opaque type ContentDisposition {
   ContentDisposition(
     disposition: String,
     name: Option(String),
     filename: Option(String),
     params: List(#(String, String)),
   )
+}
+
+/// The `disposition` token, lowercased.
+pub fn disposition(parsed: ContentDisposition) -> String {
+  parsed.disposition
+}
+
+/// The decoded `name` parameter, or `None` if absent.
+pub fn name(parsed: ContentDisposition) -> Option(String) {
+  parsed.name
+}
+
+/// The decoded `filename` parameter, or `None` if absent. Honours
+/// RFC 5987 / RFC 8187 `*`-form precedence.
+pub fn filename(parsed: ContentDisposition) -> Option(String) {
+  parsed.filename
+}
+
+/// All raw parameters as `(key, value)` pairs in input order. Includes
+/// `name` and `filename` (and `*`-form variants) before convenience
+/// decoding.
+pub fn params(parsed: ContentDisposition) -> List(#(String, String)) {
+  parsed.params
 }
 
 /// Parse a Content-Disposition header value.

--- a/src/multipartkit/encoder.gleam
+++ b/src/multipartkit/encoder.gleam
@@ -21,7 +21,7 @@ pub fn encode(boundary: String, parts: List(Part)) -> BitArray {
   let initial = <<>>
   let body =
     list.fold(parts, initial, fn(acc, the_part) {
-      let header_block = build_header_block(the_part.headers)
+      let header_block = build_header_block(part.all_headers(the_part))
       bit_array.concat([
         acc,
         dash,
@@ -29,7 +29,7 @@ pub fn encode(boundary: String, parts: List(Part)) -> BitArray {
         crlf,
         header_block,
         crlf,
-        the_part.body,
+        part.body(the_part),
         crlf,
       ])
     })
@@ -88,7 +88,7 @@ pub fn encode_stream(
           Ok(<<"\r\n":utf8>>),
         ])
       let suffix = yielder.from_list([Ok(<<"\r\n":utf8>>)])
-      yielder.append(yielder.append(prefix, the_part.body), suffix)
+      yielder.append(yielder.append(prefix, stream.body(the_part)), suffix)
     })
   let closing =
     yielder.from_list([
@@ -101,7 +101,7 @@ pub fn encode_stream(
 }
 
 fn build_stream_header_block(stream_part: StreamPart) -> BitArray {
-  build_header_block(stream_part.headers)
+  build_header_block(stream.all_headers(stream_part))
 }
 
 fn stop_after_first_error(

--- a/src/multipartkit/form.gleam
+++ b/src/multipartkit/form.gleam
@@ -5,7 +5,7 @@ import gleam/option.{None, Some}
 import gleam/result
 import gleam/string
 import multipartkit/infer
-import multipartkit/part.{type Part, Part}
+import multipartkit/part.{type Part}
 
 /// Opaque builder for multipart/form-data messages.
 ///
@@ -37,7 +37,7 @@ pub fn add_field(form: Form, name: String, value: String) -> Form {
     "form-data; name=" <> quote(safe_name),
   )
   let new_part =
-    Part(
+    part.new(
       headers: [disposition],
       name: Some(safe_name),
       filename: None,
@@ -142,7 +142,7 @@ fn build_file_part(
       <> filename_disposition_params(safe_filename),
   )
   let content_type_header = #("Content-Type", safe_content_type)
-  Part(
+  part.new(
     headers: [disposition_header, content_type_header],
     name: Some(safe_name),
     filename: Some(safe_filename),

--- a/src/multipartkit/internal/headers.gleam
+++ b/src/multipartkit/internal/headers.gleam
@@ -109,8 +109,11 @@ pub fn derive_meta(
           // disposition. Other dispositions (e.g. `attachment`) are still
           // surfaced with their raw headers but must not be picked up by
           // query helpers.
-          let #(name, filename) = case parsed.disposition {
-            "form-data" -> #(parsed.name, parsed.filename)
+          let #(name, filename) = case content_disposition.disposition(parsed) {
+            "form-data" -> #(
+              content_disposition.name(parsed),
+              content_disposition.filename(parsed),
+            )
             _ -> #(None, None)
           }
           Ok(DerivedMeta(name: name, filename: filename, content_type: ct))

--- a/src/multipartkit/limit.gleam
+++ b/src/multipartkit/limit.gleam
@@ -6,25 +6,17 @@ import gleam/result
 /// All limits are inclusive: a value equal to the limit is allowed; the
 /// `(limit + 1)`-th byte / part triggers the error.
 ///
-/// Construct via `new` (validated, recommended) or `default` (conservative
-/// presets). Direct `Limits(...)` construction stays available for
-/// trusted callers, but `new` is the supported path for any value sourced
-/// from configuration, request input, or other dynamic input.
-pub type Limits {
+/// `Limits` is an opaque type. Construct via `new` (validated,
+/// recommended) or `default_limits` (conservative presets), and inspect
+/// values through the `max_body_bytes` / `max_part_bytes` / `max_parts` /
+/// `max_header_bytes` accessor functions — direct field access was
+/// available in pre-1.0 releases but has been removed so the
+/// representation can evolve without breaking external callers.
+pub opaque type Limits {
   Limits(
-    /// Total bytes consumed from input, including boundary delimiters,
-    /// preamble, epilogue, and per-part header blocks. Triggers
-    /// `BodyTooLarge`.
     max_body_bytes: Int,
-    /// Bytes of a single part body excluding the part's header block and the
-    /// surrounding boundary lines. Triggers `PartTooLarge`.
     max_part_bytes: Int,
-    /// Maximum number of parts produced. Triggers `TooManyParts` when the
-    /// `(limit + 1)`-th part is detected.
     max_parts: Int,
-    /// Total bytes of one part's complete header block, measured from the
-    /// byte after the boundary delimiter line up to and including the blank
-    /// line that terminates the header block. Triggers `HeaderTooLarge`.
     max_header_bytes: Int,
   )
 }

--- a/src/multipartkit/parser.gleam
+++ b/src/multipartkit/parser.gleam
@@ -9,7 +9,7 @@ import multipartkit/internal/bytes
 import multipartkit/internal/headers
 import multipartkit/internal/scan
 import multipartkit/limit.{type Limits}
-import multipartkit/part.{type Part, Part}
+import multipartkit/part.{type Part}
 
 /// Parse a multipart body using `default_limits()`.
 ///
@@ -32,8 +32,8 @@ pub fn parse_with_limits(
     Error(err) -> Error(err)
     Ok(boundary_value) -> {
       let total = bit_array.byte_size(body)
-      case total > limits.max_body_bytes {
-        True -> Error(BodyTooLarge(limits.max_body_bytes))
+      case total > limit.max_body_bytes(limits) {
+        True -> Error(BodyTooLarge(limit.max_body_bytes(limits)))
         False -> {
           let pattern = scan.dash_pattern(boundary_value)
           case scan.find_delimiter(body, pattern, 0) {
@@ -65,8 +65,8 @@ fn parse_loop(
         Error(_) -> Error(UnexpectedEndOfInput)
         Ok(#(blank_at, body_start)) -> {
           let header_block_size = body_start - cursor
-          case header_block_size > limits.max_header_bytes {
-            True -> Error(HeaderTooLarge(limits.max_header_bytes))
+          case header_block_size > limit.max_header_bytes(limits) {
+            True -> Error(HeaderTooLarge(limit.max_header_bytes(limits)))
             False -> {
               let header_block =
                 bytes.slice_or_empty(body, cursor, blank_at - cursor)
@@ -80,8 +80,9 @@ fn parse_loop(
                         scan.Incomplete -> Error(UnexpectedEndOfInput)
                         scan.Found(body_end_excl, kind, after_delim) -> {
                           let body_size = body_end_excl - body_start
-                          case body_size > limits.max_part_bytes {
-                            True -> Error(PartTooLarge(limits.max_part_bytes))
+                          case body_size > limit.max_part_bytes(limits) {
+                            True ->
+                              Error(PartTooLarge(limit.max_part_bytes(limits)))
                             False -> {
                               let part_body =
                                 bytes.slice_or_empty(
@@ -90,7 +91,7 @@ fn parse_loop(
                                   body_size,
                                 )
                               let new_part =
-                                Part(
+                                part.new(
                                   headers: header_list,
                                   name: meta.name,
                                   filename: meta.filename,
@@ -98,8 +99,9 @@ fn parse_loop(
                                   body: part_body,
                                 )
                               let new_count = parts_count + 1
-                              case new_count > limits.max_parts {
-                                True -> Error(TooManyParts(limits.max_parts))
+                              case new_count > limit.max_parts(limits) {
+                                True ->
+                                  Error(TooManyParts(limit.max_parts(limits)))
                                 False ->
                                   case enforce_total(after_delim, limits) {
                                     Error(err) -> Error(err)
@@ -134,8 +136,8 @@ fn parse_loop(
 }
 
 fn enforce_total(consumed: Int, limits: Limits) -> Result(Nil, MultipartError) {
-  case consumed > limits.max_body_bytes {
-    True -> Error(BodyTooLarge(limits.max_body_bytes))
+  case consumed > limit.max_body_bytes(limits) {
+    True -> Error(BodyTooLarge(limit.max_body_bytes(limits)))
     False -> Ok(Nil)
   }
 }

--- a/src/multipartkit/part.gleam
+++ b/src/multipartkit/part.gleam
@@ -5,9 +5,12 @@ import multipartkit/internal/text
 /// A parsed multipart part.
 ///
 /// Opaque — construct with `new/5` (or receive from `parser.parse`) and
-/// inspect through `headers/1`, `name/1`, `filename/1`, `content_type/1`,
-/// and `body/1`. The internal layout may evolve to cache more derived
-/// fields without breaking external callers.
+/// inspect through `all_headers/1`, `name/1`, `filename/1`,
+/// `content_type/1`, and `body/1`. The case-insensitive
+/// `header(part, name)` and `headers(part, name)` helpers below are the
+/// supported way to look up a header value by name. The internal
+/// layout may evolve to cache more derived fields without breaking
+/// external callers.
 ///
 /// Header semantics on the headers list:
 ///

--- a/src/multipartkit/part.gleam
+++ b/src/multipartkit/part.gleam
@@ -4,11 +4,18 @@ import multipartkit/internal/text
 
 /// A parsed multipart part.
 ///
-/// `headers` keeps entries in the order they appeared on the wire; header
-/// names retain their original casing. Header values have surrounding
-/// optional whitespace stripped per RFC 7230 §3.2.4 but are otherwise
-/// preserved (no quote unescaping, no parameter normalisation, no inner
-/// whitespace collapse).
+/// Opaque — construct with `new/5` (or receive from `parser.parse`) and
+/// inspect through `headers/1`, `name/1`, `filename/1`, `content_type/1`,
+/// and `body/1`. The internal layout may evolve to cache more derived
+/// fields without breaking external callers.
+///
+/// Header semantics on the headers list:
+///
+/// - Entries are kept in the order they appeared on the wire.
+/// - Header names retain their original casing.
+/// - Header values have surrounding optional whitespace stripped per
+///   RFC 7230 §3.2.4 but are otherwise preserved (no quote unescaping,
+///   no parameter normalisation, no inner whitespace collapse).
 ///
 /// Header bytes must be valid UTF-8 — header blocks that contain non-UTF-8
 /// bytes are rejected with `InvalidHeader`. The body has no such
@@ -18,8 +25,8 @@ import multipartkit/internal/text
 /// `name`, `filename`, and `content_type` are convenience caches derived from
 /// `Content-Disposition` and `Content-Type` headers per the field/file
 /// detection rules. They are not re-derived automatically when a caller
-/// constructs a `Part` manually.
-pub type Part {
+/// constructs a `Part` manually with `new/5`.
+pub opaque type Part {
   Part(
     headers: List(#(String, String)),
     name: Option(String),
@@ -27,6 +34,55 @@ pub type Part {
     content_type: Option(String),
     body: BitArray,
   )
+}
+
+/// Construct a `Part`. The `name`, `filename`, and `content_type` fields
+/// are not re-derived from the `headers` list — pass the values you
+/// expect callers to see, or use `parser.parse` for automatic
+/// derivation.
+pub fn new(
+  headers headers: List(#(String, String)),
+  name name: Option(String),
+  filename filename: Option(String),
+  content_type content_type: Option(String),
+  body body: BitArray,
+) -> Part {
+  Part(
+    headers: headers,
+    name: name,
+    filename: filename,
+    content_type: content_type,
+    body: body,
+  )
+}
+
+/// All headers as `(name, value)` pairs in input order.
+pub fn all_headers(part: Part) -> List(#(String, String)) {
+  part.headers
+}
+
+/// The convenience `name` field derived from `Content-Disposition` for
+/// `form-data` parts, or `None` for non-form parts and parts without a
+/// disposition header.
+pub fn name(part: Part) -> Option(String) {
+  part.name
+}
+
+/// The convenience `filename` field derived from `Content-Disposition`
+/// for `form-data` parts, or `None`.
+pub fn filename(part: Part) -> Option(String) {
+  part.filename
+}
+
+/// The `Content-Type` header value, or `None` if the part has no
+/// `Content-Type` header.
+pub fn content_type(part: Part) -> Option(String) {
+  part.content_type
+}
+
+/// The raw body bytes of the part.
+pub fn body(part: Part) -> BitArray {
+  part.body
 }
 
 /// Return the first header value whose name matches `name` ASCII
@@ -39,7 +95,7 @@ pub fn header(part: Part, name: String) -> Option(String) {
 }
 
 /// Return all header values whose name matches `name` ASCII case-insensitively
-/// in the order they appear in `part.headers`.
+/// in the order they appear in the part headers.
 pub fn headers(part: Part, name: String) -> List(String) {
   find_header(part.headers, name)
 }

--- a/src/multipartkit/query.gleam
+++ b/src/multipartkit/query.gleam
@@ -20,7 +20,7 @@ pub fn field(parts: List(Part), name: String) -> Option(String) {
   case find_text_field(parts, name) {
     None -> None
     Some(found_part) ->
-      case bit_array.to_string(found_part.body) {
+      case bit_array.to_string(part.body(found_part)) {
         Ok(value) -> Some(value)
         Error(Nil) -> None
       }
@@ -36,7 +36,7 @@ pub fn required_field(
   case find_text_field(parts, name) {
     None -> Error(MissingField(name))
     Some(found_part) ->
-      case bit_array.to_string(found_part.body) {
+      case bit_array.to_string(part.body(found_part)) {
         Ok(value) -> Ok(value)
         Error(Nil) -> Error(InvalidUtf8Field(name))
       }
@@ -49,7 +49,7 @@ pub fn required_field(
 pub fn fields(parts: List(Part), name: String) -> List(String) {
   parts
   |> list.filter(fn(p) { is_text_field_named(p, name) })
-  |> list.filter_map(fn(p) { bit_array.to_string(p.body) })
+  |> list.filter_map(fn(p) { bit_array.to_string(part.body(p)) })
 }
 
 /// First file part with the given `name`. `filename = Some("")` still counts
@@ -91,7 +91,7 @@ fn collect_names(
   case remaining {
     [] -> list.reverse(acc)
     [the_part, ..rest] ->
-      case the_part.name {
+      case part.name(the_part) {
         None -> collect_names(rest, seen, acc)
         Some(name) ->
           case list.contains(seen, name) {
@@ -110,14 +110,14 @@ fn find_text_field(parts: List(Part), name: String) -> Option(Part) {
 }
 
 fn is_text_field_named(the_part: Part, name: String) -> Bool {
-  case the_part.name, the_part.filename {
+  case part.name(the_part), part.filename(the_part) {
     Some(value), None -> value == name
     _, _ -> False
   }
 }
 
 fn is_file_named(the_part: Part, name: String) -> Bool {
-  case the_part.name, the_part.filename {
+  case part.name(the_part), part.filename(the_part) {
     Some(value), Some(_) -> value == name
     _, _ -> False
   }

--- a/src/multipartkit/stream.gleam
+++ b/src/multipartkit/stream.gleam
@@ -14,22 +14,27 @@ import multipartkit/part.{type Part}
 
 /// One streamed multipart part.
 ///
-/// `body` is single-pass; once consumed it cannot be replayed. Errors that
-/// arise while reading the body (`PartTooLarge`, `UnexpectedEndOfInput`,
-/// etc.) are surfaced inline as `Error(_)` items rather than swallowed.
+/// Opaque — inspect through `headers/1`, `name/1`, `filename/1`,
+/// `content_type/1`, and `body/1`. The internal layout may evolve as
+/// the streaming surface stabilises (see issue #7 for the chunked-body
+/// follow-up) without breaking external callers.
 ///
-/// In v0.1.0 the input chunks yielder is consumed lazily, but each
-/// `StreamPart` body is materialised as a single buffered chunk before the
-/// part is yielded. The body yielder therefore always emits at most one
-/// `Ok(BitArray)` (or one `Error(_)`). Per-part memory is bounded by
-/// `max_part_bytes`. True chunk-by-chunk body streaming is on the roadmap
-/// but is not part of v0.1.0.
+/// Body semantics:
 ///
-/// Note: the spec lists `body` as `iterator.Iterator(_)`. v0.1.0 uses
-/// `gleam/yielder.Yielder(_)` because gleam_stdlib 1.0.0 dropped the
-/// `iterator` module. The streaming surface is experimental and the type
-/// may change before v1.0.0.
-pub type StreamPart {
+/// - `body/1` returns a single-pass yielder; once consumed it cannot be
+///   replayed. Errors that arise while reading the body
+///   (`PartTooLarge`, `UnexpectedEndOfInput`, etc.) are surfaced inline
+///   as `Error(_)` items rather than swallowed.
+/// - In the current release each `StreamPart` body is materialised as a
+///   single buffered chunk before the part is yielded. The body yielder
+///   therefore always emits at most one `Ok(BitArray)` (or one
+///   `Error(_)`). Per-part memory is bounded by `max_part_bytes`. True
+///   chunk-by-chunk body streaming is on the roadmap.
+///
+/// Note: the public spec describes `body` as `iterator.Iterator(_)`.
+/// The current implementation uses `gleam/yielder.Yielder(_)` because
+/// gleam_stdlib 1.0.0 dropped the `iterator` module.
+pub opaque type StreamPart {
   StreamPart(
     headers: List(#(String, String)),
     name: Option(String),
@@ -37,6 +42,36 @@ pub type StreamPart {
     content_type: Option(String),
     body: Yielder(Result(BitArray, MultipartError)),
   )
+}
+
+/// All headers as `(name, value)` pairs in input order.
+pub fn all_headers(stream_part: StreamPart) -> List(#(String, String)) {
+  stream_part.headers
+}
+
+/// The convenience `name` field derived from `Content-Disposition` for
+/// `form-data` parts, or `None`.
+pub fn name(stream_part: StreamPart) -> Option(String) {
+  stream_part.name
+}
+
+/// The convenience `filename` field derived from `Content-Disposition`
+/// for `form-data` parts, or `None`.
+pub fn filename(stream_part: StreamPart) -> Option(String) {
+  stream_part.filename
+}
+
+/// The `Content-Type` header value, or `None`.
+pub fn content_type(stream_part: StreamPart) -> Option(String) {
+  stream_part.content_type
+}
+
+/// The single-pass body yielder. See the type-level doc for streaming
+/// semantics.
+pub fn body(
+  stream_part: StreamPart,
+) -> Yielder(Result(BitArray, MultipartError)) {
+  stream_part.body
 }
 
 /// Parse a stream of input chunks using `default_limits()`.
@@ -149,7 +184,8 @@ fn step_find_first(
       case pull_chunk(state) {
         Pulled(next) -> step_find_first(next)
         Exhausted -> halt_with(state, UnexpectedEndOfInput)
-        OverBody -> halt_with(state, BodyTooLarge(state.limits.max_body_bytes))
+        OverBody ->
+          halt_with(state, BodyTooLarge(limit.max_body_bytes(state.limits)))
       }
   }
 }
@@ -164,7 +200,8 @@ fn step_produce_next(
       case pull_chunk(state) {
         Pulled(next) -> step_produce_next(next)
         Exhausted -> halt_with(state, UnexpectedEndOfInput)
-        OverBody -> halt_with(state, BodyTooLarge(state.limits.max_body_bytes))
+        OverBody ->
+          halt_with(state, BodyTooLarge(limit.max_body_bytes(state.limits)))
       }
   }
 }
@@ -185,7 +222,7 @@ fn pull_chunk(state: StreamState) -> PullOutcome {
         yielder.Next(chunk, rest) -> {
           let size = bit_array.byte_size(chunk)
           let new_pulled = state.bytes_pulled + size
-          case new_pulled > state.limits.max_body_bytes {
+          case new_pulled > limit.max_body_bytes(state.limits) {
             True -> OverBody
             False ->
               Pulled(
@@ -215,8 +252,8 @@ fn finalise_headers(
   body_start: Int,
 ) -> PartOutcome {
   let header_block_size = body_start - state.cursor
-  case header_block_size > state.limits.max_header_bytes {
-    True -> Failed(HeaderTooLarge(state.limits.max_header_bytes))
+  case header_block_size > limit.max_header_bytes(state.limits) {
+    True -> Failed(HeaderTooLarge(limit.max_header_bytes(state.limits)))
     False -> {
       let header_block =
         bytes.slice_or_empty(state.buf, state.cursor, blank_at - state.cursor)
@@ -263,12 +300,12 @@ fn finalise_part(
   meta: internal_headers.DerivedMeta,
 ) -> PartOutcome {
   let body_size = body_end_excl - body_start
-  case body_size > state.limits.max_part_bytes {
-    True -> Failed(PartTooLarge(state.limits.max_part_bytes))
+  case body_size > limit.max_part_bytes(state.limits) {
+    True -> Failed(PartTooLarge(limit.max_part_bytes(state.limits)))
     False -> {
       let new_count = state.parts_count + 1
-      case new_count > state.limits.max_parts {
-        True -> Failed(TooManyParts(state.limits.max_parts))
+      case new_count > limit.max_parts(state.limits) {
+        True -> Failed(TooManyParts(limit.max_parts(state.limits)))
         False -> {
           let part_body = bytes.slice_or_empty(state.buf, body_start, body_size)
           let stream_part =
@@ -318,11 +355,11 @@ fn compact_buffer(state: StreamState) -> StreamState {
 /// buffered parse result into the streaming API surface.
 pub fn from_part(the_part: Part) -> StreamPart {
   StreamPart(
-    headers: the_part.headers,
-    name: the_part.name,
-    filename: the_part.filename,
-    content_type: the_part.content_type,
-    body: yielder.from_list([Ok(the_part.body)]),
+    headers: part.all_headers(the_part),
+    name: part.name(the_part),
+    filename: part.filename(the_part),
+    content_type: part.content_type(the_part),
+    body: yielder.from_list([Ok(part.body(the_part))]),
   )
 }
 

--- a/src/multipartkit/stream.gleam
+++ b/src/multipartkit/stream.gleam
@@ -14,7 +14,7 @@ import multipartkit/part.{type Part}
 
 /// One streamed multipart part.
 ///
-/// Opaque — inspect through `headers/1`, `name/1`, `filename/1`,
+/// Opaque — inspect through `all_headers/1`, `name/1`, `filename/1`,
 /// `content_type/1`, and `body/1`. The internal layout may evolve as
 /// the streaming surface stabilises (see issue #7 for the chunked-body
 /// follow-up) without breaking external callers.

--- a/src/multipartkit/validate.gleam
+++ b/src/multipartkit/validate.gleam
@@ -12,7 +12,7 @@ import multipartkit/part.{type Part}
 /// Return `True` if any part is a text field with the given `name`.
 pub fn has_field(parts: List(Part), name: String) -> Bool {
   list.any(parts, fn(p) {
-    case p.name, p.filename {
+    case part.name(p), part.filename(p) {
       Some(value), None -> value == name
       _, _ -> False
     }
@@ -22,7 +22,7 @@ pub fn has_field(parts: List(Part), name: String) -> Bool {
 /// Validate that the part body does not exceed `max` bytes.
 pub fn max_file_size(the_part: Part, max: Int) -> Result(Part, MultipartError) {
   use <- bool.guard(
-    when: bit_array.byte_size(the_part.body) > max,
+    when: bit_array.byte_size(part.body(the_part)) > max,
     return: Error(PartTooLarge(max)),
   )
   Ok(the_part)
@@ -34,7 +34,7 @@ pub fn allowed_content_types(
   the_part: Part,
   allowed: List(String),
 ) -> Result(Part, MultipartError) {
-  let actual = case the_part.content_type {
+  let actual = case part.content_type(the_part) {
     Some(value) -> value
     None -> ""
   }

--- a/test/multipartkit/content_disposition_test.gleam
+++ b/test/multipartkit/content_disposition_test.gleam
@@ -5,21 +5,21 @@ import multipartkit/error.{InvalidContentDisposition}
 
 pub fn parse_form_data_basic_test() {
   let assert Ok(parsed) = content_disposition.parse("form-data; name=\"title\"")
-  parsed.disposition |> should.equal("form-data")
-  parsed.name |> should.equal(Some("title"))
-  parsed.filename |> should.equal(None)
+  content_disposition.disposition(parsed) |> should.equal("form-data")
+  content_disposition.name(parsed) |> should.equal(Some("title"))
+  content_disposition.filename(parsed) |> should.equal(None)
 }
 
 pub fn parse_normalises_disposition_case_test() {
   let assert Ok(parsed) = content_disposition.parse("Form-Data; name=\"title\"")
-  parsed.disposition |> should.equal("form-data")
+  content_disposition.disposition(parsed) |> should.equal("form-data")
 }
 
 pub fn parse_attachment_disposition_test() {
   let assert Ok(parsed) =
     content_disposition.parse("attachment; filename=\"a.txt\"")
-  parsed.disposition |> should.equal("attachment")
-  parsed.filename |> should.equal(Some("a.txt"))
+  content_disposition.disposition(parsed) |> should.equal("attachment")
+  content_disposition.filename(parsed) |> should.equal(Some("a.txt"))
 }
 
 pub fn parse_form_data_with_filename_test() {
@@ -27,14 +27,14 @@ pub fn parse_form_data_with_filename_test() {
     content_disposition.parse(
       "form-data; name=\"upload\"; filename=\"photo.jpg\"",
     )
-  parsed.name |> should.equal(Some("upload"))
-  parsed.filename |> should.equal(Some("photo.jpg"))
+  content_disposition.name(parsed) |> should.equal(Some("upload"))
+  content_disposition.filename(parsed) |> should.equal(Some("photo.jpg"))
 }
 
 pub fn parse_quoted_string_with_escapes_test() {
   let assert Ok(parsed) =
     content_disposition.parse("form-data; name=\"a\\\"b\\\\c\"")
-  parsed.name |> should.equal(Some("a\"b\\c"))
+  content_disposition.name(parsed) |> should.equal(Some("a\"b\\c"))
 }
 
 pub fn parse_filename_with_spaces_test() {
@@ -42,7 +42,7 @@ pub fn parse_filename_with_spaces_test() {
     content_disposition.parse(
       "form-data; name=\"upload\"; filename=\"my file.txt\"",
     )
-  parsed.filename |> should.equal(Some("my file.txt"))
+  content_disposition.filename(parsed) |> should.equal(Some("my file.txt"))
 }
 
 pub fn parse_filename_star_utf8_test() {
@@ -51,7 +51,7 @@ pub fn parse_filename_star_utf8_test() {
     content_disposition.parse(
       "form-data; name=\"file\"; filename*=UTF-8''r%C3%A9sum%C3%A9.txt",
     )
-  parsed.filename |> should.equal(Some("résumé.txt"))
+  content_disposition.filename(parsed) |> should.equal(Some("résumé.txt"))
 }
 
 pub fn parse_filename_star_iso_8859_1_test() {
@@ -59,7 +59,7 @@ pub fn parse_filename_star_iso_8859_1_test() {
     content_disposition.parse(
       "form-data; name=\"file\"; filename*=ISO-8859-1''na%EFve.txt",
     )
-  parsed.filename |> should.equal(Some("naïve.txt"))
+  content_disposition.filename(parsed) |> should.equal(Some("naïve.txt"))
 }
 
 pub fn parse_filename_star_takes_precedence_test() {
@@ -67,7 +67,7 @@ pub fn parse_filename_star_takes_precedence_test() {
     content_disposition.parse(
       "form-data; name=\"x\"; filename=\"plain.txt\"; filename*=UTF-8''star.txt",
     )
-  parsed.filename |> should.equal(Some("star.txt"))
+  content_disposition.filename(parsed) |> should.equal(Some("star.txt"))
 }
 
 pub fn parse_filename_star_unsupported_charset_rejected_test() {
@@ -93,7 +93,7 @@ pub fn parse_preserves_param_order_test() {
     content_disposition.parse(
       "form-data; alpha=1; beta=\"two\"; alpha=overridden",
     )
-  parsed.params
+  content_disposition.params(parsed)
   |> should.equal([
     #("alpha", "1"),
     #("beta", "two"),
@@ -104,7 +104,7 @@ pub fn parse_preserves_param_order_test() {
 pub fn parse_first_occurrence_wins_for_convenience_test() {
   let assert Ok(parsed) =
     content_disposition.parse("form-data; name=\"first\"; name=\"second\"")
-  parsed.name |> should.equal(Some("first"))
+  content_disposition.name(parsed) |> should.equal(Some("first"))
 }
 
 pub fn parse_empty_disposition_token_rejected_test() {
@@ -114,15 +114,15 @@ pub fn parse_empty_disposition_token_rejected_test() {
 
 pub fn parse_tolerates_no_params_test() {
   let assert Ok(parsed) = content_disposition.parse("inline")
-  parsed.disposition |> should.equal("inline")
-  parsed.name |> should.equal(None)
-  parsed.filename |> should.equal(None)
-  parsed.params |> should.equal([])
+  content_disposition.disposition(parsed) |> should.equal("inline")
+  content_disposition.name(parsed) |> should.equal(None)
+  content_disposition.filename(parsed) |> should.equal(None)
+  content_disposition.params(parsed) |> should.equal([])
 }
 
 pub fn parse_filename_empty_quoted_test() {
   // HTML5 unselected file input: filename=""
   let assert Ok(parsed) =
     content_disposition.parse("form-data; name=\"upload\"; filename=\"\"")
-  parsed.filename |> should.equal(Some(""))
+  content_disposition.filename(parsed) |> should.equal(Some(""))
 }

--- a/test/multipartkit/encoder_test.gleam
+++ b/test/multipartkit/encoder_test.gleam
@@ -6,7 +6,7 @@ import gleeunit/should
 import multipartkit/encoder
 import multipartkit/form
 import multipartkit/parser
-import multipartkit/part.{Part}
+import multipartkit/part
 import multipartkit/stream
 
 pub fn encode_zero_parts_test() {
@@ -16,7 +16,7 @@ pub fn encode_zero_parts_test() {
 
 pub fn encode_single_field_test() {
   let part_value =
-    Part(
+    part.new(
       headers: [#("Content-Disposition", "form-data; name=\"a\"")],
       name: Some("a"),
       filename: None,
@@ -33,7 +33,7 @@ pub fn encode_emits_headers_verbatim_test() {
   // The encoder should not synthesize headers; it should emit exactly what
   // we pass.
   let part_value =
-    Part(
+    part.new(
       headers: [#("X-First", "1"), #("X-Second", "two")],
       name: None,
       filename: None,
@@ -64,11 +64,11 @@ pub fn encode_form_round_trips_test() {
     |> form.add_file("data", "x.bin", "application/octet-stream", <<1, 2, 3, 4>>)
   let #(content_type, body) = encoder.encode_form(form_value)
   let assert Ok([title_part, data_part]) = parser.parse(body, content_type)
-  title_part.name |> should.equal(Some("title"))
-  title_part.body |> should.equal(<<"ok":utf8>>)
-  data_part.filename |> should.equal(Some("x.bin"))
-  data_part.content_type |> should.equal(Some("application/octet-stream"))
-  data_part.body |> should.equal(<<1, 2, 3, 4>>)
+  part.name(title_part) |> should.equal(Some("title"))
+  part.body(title_part) |> should.equal(<<"ok":utf8>>)
+  part.filename(data_part) |> should.equal(Some("x.bin"))
+  part.content_type(data_part) |> should.equal(Some("application/octet-stream"))
+  part.body(data_part) |> should.equal(<<1, 2, 3, 4>>)
 }
 
 pub fn encode_form_generates_fresh_boundary_test() {
@@ -86,7 +86,7 @@ pub fn encode_form_generates_fresh_boundary_test() {
 
 pub fn encode_stream_round_trips_via_buffer_test() {
   let part0 =
-    Part(
+    part.new(
       headers: [#("Content-Disposition", "form-data; name=\"a\"")],
       name: Some("a"),
       filename: None,
@@ -101,8 +101,8 @@ pub fn encode_stream_round_trips_via_buffer_test() {
     Ok(bytes) -> {
       let assert Ok([parsed]) =
         parser.parse(bytes, "multipart/form-data; boundary=B")
-      parsed.name |> should.equal(Some("a"))
-      parsed.body |> should.equal(<<"v":utf8>>)
+      part.name(parsed) |> should.equal(Some("a"))
+      part.body(parsed) |> should.equal(<<"v":utf8>>)
     }
     Error(_) -> should.fail()
   }

--- a/test/multipartkit/form_rfc5987_test.gleam
+++ b/test/multipartkit/form_rfc5987_test.gleam
@@ -13,6 +13,7 @@ import multipartkit
 import multipartkit/encoder
 import multipartkit/form
 import multipartkit/parser
+import multipartkit/part
 
 // ---------------------------------------------------------------
 // ASCII-only filename: behaviour MUST be unchanged from before this
@@ -69,7 +70,7 @@ pub fn cjk_filename_round_trips_via_rfc5987_test() {
     |> form.add_file("file", "写真.png", "image/png", <<"ASCII":utf8>>)
   let #(ct, body) = multipartkit.encode_form(f)
   let assert Ok([the_part]) = parser.parse(body, ct)
-  the_part.filename |> should.equal(Some("写真.png"))
+  part.filename(the_part) |> should.equal(Some("写真.png"))
 }
 
 // ---------------------------------------------------------------
@@ -98,7 +99,7 @@ pub fn latin_filename_round_trips_test() {
     |> form.add_file("file", "Naïve.txt", "text/plain", <<"x":utf8>>)
   let #(ct, body) = multipartkit.encode_form(f)
   let assert Ok([the_part]) = parser.parse(body, ct)
-  the_part.filename |> should.equal(Some("Naïve.txt"))
+  part.filename(the_part) |> should.equal(Some("Naïve.txt"))
 }
 
 // ---------------------------------------------------------------
@@ -112,7 +113,7 @@ pub fn emoji_filename_round_trips_test() {
     |> form.add_file("file", "globe🌏.png", "image/png", <<"x":utf8>>)
   let #(ct, body) = multipartkit.encode_form(f)
   let assert Ok([the_part]) = parser.parse(body, ct)
-  the_part.filename |> should.equal(Some("globe🌏.png"))
+  part.filename(the_part) |> should.equal(Some("globe🌏.png"))
 }
 
 // ---------------------------------------------------------------
@@ -134,5 +135,5 @@ pub fn ascii_filename_with_quote_keeps_legacy_only_test() {
   // And it still round-trips:
   let #(ct, body2) = multipartkit.encode_form(f)
   let assert Ok([p]) = parser.parse(body2, ct)
-  p.filename |> should.equal(Some("a\"b.txt"))
+  part.filename(p) |> should.equal(Some("a\"b.txt"))
 }

--- a/test/multipartkit/form_test.gleam
+++ b/test/multipartkit/form_test.gleam
@@ -5,7 +5,7 @@ import multipartkit/encoder
 import multipartkit/form
 import multipartkit/infer
 import multipartkit/parser
-import multipartkit/part.{Part}
+import multipartkit/part
 
 pub fn empty_form_test() {
   form.new()
@@ -21,10 +21,10 @@ pub fn add_field_appends_in_order_test() {
   let parts = form.parts(f)
   case parts {
     [first, second] -> {
-      first.name |> should.equal(Some("a"))
-      first.body |> should.equal(<<"1":utf8>>)
-      second.name |> should.equal(Some("b"))
-      second.body |> should.equal(<<"2":utf8>>)
+      part.name(first) |> should.equal(Some("a"))
+      part.body(first) |> should.equal(<<"1":utf8>>)
+      part.name(second) |> should.equal(Some("b"))
+      part.body(second) |> should.equal(<<"2":utf8>>)
     }
     _ -> should.fail()
   }
@@ -35,9 +35,9 @@ pub fn add_file_sets_metadata_test() {
     form.new()
     |> form.add_file("upload", "doc.pdf", "application/pdf", <<"%PDF":utf8>>)
   let assert [the_part] = form.parts(f)
-  the_part.name |> should.equal(Some("upload"))
-  the_part.filename |> should.equal(Some("doc.pdf"))
-  the_part.content_type |> should.equal(Some("application/pdf"))
+  part.name(the_part) |> should.equal(Some("upload"))
+  part.filename(the_part) |> should.equal(Some("doc.pdf"))
+  part.content_type(the_part) |> should.equal(Some("application/pdf"))
 }
 
 pub fn add_file_auto_falls_through_to_octet_stream_test() {
@@ -46,7 +46,7 @@ pub fn add_file_auto_falls_through_to_octet_stream_test() {
     form.new()
     |> form.add_file_auto("blob", "any.bin", <<1, 2, 3>>)
   let assert [the_part] = form.parts(f)
-  the_part.content_type |> should.equal(Some("application/octet-stream"))
+  part.content_type(the_part) |> should.equal(Some("application/octet-stream"))
 }
 
 pub fn add_file_auto_with_filename_inferer_test() {
@@ -64,7 +64,7 @@ pub fn add_file_auto_with_filename_inferer_test() {
     form.new()
     |> form.add_file_auto_with("blob", "x.png", <<1, 2>>, inferer)
   let assert [the_part] = form.parts(f)
-  the_part.content_type |> should.equal(Some("image/png"))
+  part.content_type(the_part) |> should.equal(Some("image/png"))
 }
 
 pub fn add_file_auto_with_bytes_inferer_fallback_test() {
@@ -76,12 +76,12 @@ pub fn add_file_auto_with_bytes_inferer_fallback_test() {
     form.new()
     |> form.add_file_auto_with("blob", "no-ext", <<0, 1, 2>>, inferer)
   let assert [the_part] = form.parts(f)
-  the_part.content_type |> should.equal(Some("application/x-custom"))
+  part.content_type(the_part) |> should.equal(Some("application/x-custom"))
 }
 
 pub fn unsafe_add_part_inserts_verbatim_test() {
   let manual =
-    Part(
+    part.new(
       headers: [#("X-Custom", "v")],
       name: None,
       filename: None,
@@ -92,8 +92,8 @@ pub fn unsafe_add_part_inserts_verbatim_test() {
     form.new()
     |> form.unsafe_add_part(manual)
   let assert [the_part] = form.parts(f)
-  the_part.headers |> should.equal([#("X-Custom", "v")])
-  the_part.name |> should.equal(None)
+  part.all_headers(the_part) |> should.equal([#("X-Custom", "v")])
+  part.name(the_part) |> should.equal(None)
 }
 
 pub fn form_round_trips_with_multiple_parts_test() {
@@ -106,14 +106,14 @@ pub fn form_round_trips_with_multiple_parts_test() {
   let assert Ok(parts) = parser.parse(body, content_type)
   case parts {
     [first, second, third] -> {
-      first.name |> should.equal(Some("name"))
-      first.body |> should.equal(<<"Alice":utf8>>)
-      second.name |> should.equal(Some("notes"))
-      second.body |> should.equal(<<"hello world":utf8>>)
-      third.name |> should.equal(Some("avatar"))
-      third.filename |> should.equal(Some("a.png"))
-      third.content_type |> should.equal(Some("image/png"))
-      third.body |> should.equal(<<0x89, 0x50, 0x4E, 0x47>>)
+      part.name(first) |> should.equal(Some("name"))
+      part.body(first) |> should.equal(<<"Alice":utf8>>)
+      part.name(second) |> should.equal(Some("notes"))
+      part.body(second) |> should.equal(<<"hello world":utf8>>)
+      part.name(third) |> should.equal(Some("avatar"))
+      part.filename(third) |> should.equal(Some("a.png"))
+      part.content_type(third) |> should.equal(Some("image/png"))
+      part.body(third) |> should.equal(<<0x89, 0x50, 0x4E, 0x47>>)
     }
     _ -> should.fail()
   }
@@ -129,9 +129,9 @@ pub fn add_field_strips_crlf_from_name_test() {
   let assert Ok([the_part]) = parser.parse(body, content_type)
   // After CR/LF stripping the round-tripped name no longer contains the
   // injected newline.
-  the_part.name |> should.equal(Some("dangerousX-Injected: yes"))
+  part.name(the_part) |> should.equal(Some("dangerousX-Injected: yes"))
   // Only the legitimate Content-Disposition header is produced.
-  the_part.headers
+  part.all_headers(the_part)
   |> should.equal([
     #("Content-Disposition", "form-data; name=\"dangerousX-Injected: yes\""),
   ])
@@ -149,7 +149,7 @@ pub fn add_file_strips_crlf_from_filename_test() {
   let #(content_type, body) = encoder.encode_form(f)
   let assert Ok([the_part]) = parser.parse(body, content_type)
   // Re-parsed filename has the CRLF removed.
-  the_part.filename |> should.equal(Some("evilname.txt"))
+  part.filename(the_part) |> should.equal(Some("evilname.txt"))
 }
 
 pub fn add_file_strips_crlf_from_content_type_test() {
@@ -160,15 +160,17 @@ pub fn add_file_strips_crlf_from_content_type_test() {
     |> form.add_file("upload", "x.txt", "text/plain\r\nX-Evil: 1", <<"hi":utf8>>)
   let assert [the_part] = form.parts(f)
   // Cached metadata is sanitized to match the serialized form.
-  the_part.content_type
+  part.content_type(the_part)
   |> should.equal(Some("text/plainX-Evil: 1"))
   // Round-trip the form and confirm only the intended Content-Type survives.
   let #(content_type, body) = encoder.encode_form(f)
   let assert Ok([reparsed]) = parser.parse(body, content_type)
-  reparsed.content_type
+  part.content_type(reparsed)
   |> should.equal(Some("text/plainX-Evil: 1"))
   // No spurious X-Evil header was injected.
-  case list.find(reparsed.headers, fn(entry) { entry.0 == "X-Evil" }) {
+  case
+    list.find(part.all_headers(reparsed), fn(entry) { entry.0 == "X-Evil" })
+  {
     Error(Nil) -> Nil
     Ok(_) -> should.fail()
   }
@@ -184,7 +186,7 @@ pub fn add_file_auto_with_strips_crlf_from_inferred_content_type_test() {
     form.new()
     |> form.add_file_auto_with("upload", "x.txt", <<"hi":utf8>>, inferer)
   let assert [the_part] = form.parts(f)
-  the_part.content_type
+  part.content_type(the_part)
   |> should.equal(Some("text/plainX-Evil: 1"))
 }
 
@@ -203,10 +205,10 @@ pub fn form_metadata_matches_round_tripped_parts_test() {
   let assert Ok(reparsed) = parser.parse(body, content_type)
   case cached, reparsed {
     [c1, c2], [r1, r2] -> {
-      c1.name |> should.equal(r1.name)
-      c2.name |> should.equal(r2.name)
-      c2.filename |> should.equal(r2.filename)
-      c2.content_type |> should.equal(r2.content_type)
+      part.name(c1) |> should.equal(part.name(r1))
+      part.name(c2) |> should.equal(part.name(r2))
+      part.filename(c2) |> should.equal(part.filename(r2))
+      part.content_type(c2) |> should.equal(part.content_type(r2))
     }
     _, _ -> should.fail()
   }
@@ -219,5 +221,5 @@ pub fn add_field_with_quote_in_value_round_trips_test() {
     |> form.add_field("k", "value with \" quote")
   let #(content_type, body) = encoder.encode_form(f)
   let assert Ok([p]) = parser.parse(body, content_type)
-  p.body |> should.equal(<<"value with \" quote":utf8>>)
+  part.body(p) |> should.equal(<<"value with \" quote":utf8>>)
 }

--- a/test/multipartkit/parser_limits_test.gleam
+++ b/test/multipartkit/parser_limits_test.gleam
@@ -3,7 +3,7 @@ import gleeunit/should
 import multipartkit/error.{
   BodyTooLarge, HeaderTooLarge, PartTooLarge, TooManyParts,
 }
-import multipartkit/limit.{Limits}
+import multipartkit/limit
 import multipartkit/parser
 
 const ct = "multipart/form-data; boundary=B"
@@ -16,8 +16,8 @@ fn one_part_body() -> BitArray {
 
 pub fn body_too_large_test() {
   let body = one_part_body()
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 5,
       max_part_bytes: 1000,
       max_parts: 100,
@@ -30,8 +30,8 @@ pub fn body_too_large_test() {
 pub fn body_at_limit_succeeds_test() {
   let body = one_part_body()
   let exact = bit_array.byte_size(body)
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: exact,
       max_part_bytes: 1000,
       max_parts: 100,
@@ -45,8 +45,8 @@ pub fn body_at_limit_succeeds_test() {
 
 pub fn part_too_large_test() {
   let body = one_part_body()
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 1000,
       max_part_bytes: 4,
       max_parts: 100,
@@ -59,8 +59,8 @@ pub fn part_too_large_test() {
 
 pub fn part_at_limit_succeeds_test() {
   let body = one_part_body()
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 1000,
       max_part_bytes: 5,
       max_parts: 100,
@@ -76,8 +76,8 @@ pub fn too_many_parts_test() {
   let body = <<
     "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--B\r\nContent-Disposition: form-data; name=\"b\"\r\n\r\n2\r\n--B--\r\n":utf8,
   >>
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 1000,
       max_part_bytes: 1000,
       max_parts: 1,
@@ -91,8 +91,8 @@ pub fn header_too_large_test() {
   let body = <<
     "--B\r\nContent-Disposition: form-data; name=\"a\"\r\nX-Custom: very-long-header-value-here\r\n\r\nx\r\n--B--\r\n":utf8,
   >>
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 1000,
       max_part_bytes: 1000,
       max_parts: 100,
@@ -108,8 +108,8 @@ pub fn limit_includes_blank_line_terminator_test() {
   let body = <<
     "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nx\r\n--B--\r\n":utf8,
   >>
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 1000,
       max_part_bytes: 1000,
       max_parts: 100,
@@ -119,8 +119,8 @@ pub fn limit_includes_blank_line_terminator_test() {
     Ok(_) -> Nil
     _ -> should.fail()
   }
-  let strict =
-    Limits(
+  let assert Ok(strict) =
+    limit.new(
       max_body_bytes: 1000,
       max_part_bytes: 1000,
       max_parts: 100,

--- a/test/multipartkit/parser_line_endings_test.gleam
+++ b/test/multipartkit/parser_line_endings_test.gleam
@@ -1,6 +1,7 @@
 import gleam/option.{Some}
 import gleeunit/should
 import multipartkit/parser
+import multipartkit/part
 
 const ct = "multipart/form-data; boundary=B"
 
@@ -9,8 +10,8 @@ pub fn parse_lf_only_line_endings_test() {
     "--B\nContent-Disposition: form-data; name=\"a\"\n\nhello\n--B--\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.name |> should.equal(Some("a"))
-  field_part.body |> should.equal(<<"hello":utf8>>)
+  part.name(field_part) |> should.equal(Some("a"))
+  part.body(field_part) |> should.equal(<<"hello":utf8>>)
 }
 
 pub fn parse_mixed_line_endings_test() {
@@ -19,8 +20,8 @@ pub fn parse_mixed_line_endings_test() {
     "--B\r\nContent-Disposition: form-data; name=\"a\"\nContent-Type: text/plain\r\n\nhello\r\n--B--\r\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.name |> should.equal(Some("a"))
-  field_part.body |> should.equal(<<"hello":utf8>>)
+  part.name(field_part) |> should.equal(Some("a"))
+  part.body(field_part) |> should.equal(<<"hello":utf8>>)
 }
 
 pub fn parse_bare_cr_inside_body_is_preserved_test() {
@@ -30,7 +31,7 @@ pub fn parse_bare_cr_inside_body_is_preserved_test() {
     13, "bar\r\n--B--\r\n":utf8,
   >>
   let assert Ok([file_part]) = parser.parse(body, ct)
-  file_part.body |> should.equal(<<"foo":utf8, 13, "bar":utf8>>)
+  part.body(file_part) |> should.equal(<<"foo":utf8, 13, "bar":utf8>>)
 }
 
 pub fn parse_lf_terminated_closing_test() {
@@ -38,5 +39,5 @@ pub fn parse_lf_terminated_closing_test() {
     "--B\nContent-Disposition: form-data; name=\"a\"\n\nx\n--B--\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.body |> should.equal(<<"x":utf8>>)
+  part.body(field_part) |> should.equal(<<"x":utf8>>)
 }

--- a/test/multipartkit/parser_test.gleam
+++ b/test/multipartkit/parser_test.gleam
@@ -1,6 +1,7 @@
 import gleam/option.{None, Some}
 import gleeunit/should
 import multipartkit/parser
+import multipartkit/part
 
 const ct = "multipart/form-data; boundary=BOUNDARY"
 
@@ -13,10 +14,10 @@ pub fn parse_single_text_field_test() {
     "--BOUNDARY\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nhello\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.name |> should.equal(Some("a"))
-  field_part.filename |> should.equal(None)
-  field_part.content_type |> should.equal(None)
-  field_part.body |> should.equal(<<"hello":utf8>>)
+  part.name(field_part) |> should.equal(Some("a"))
+  part.filename(field_part) |> should.equal(None)
+  part.content_type(field_part) |> should.equal(None)
+  part.body(field_part) |> should.equal(<<"hello":utf8>>)
 }
 
 pub fn parse_two_fields_preserves_order_test() {
@@ -24,10 +25,10 @@ pub fn parse_two_fields_preserves_order_test() {
     "--BOUNDARY\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--BOUNDARY\r\nContent-Disposition: form-data; name=\"b\"\r\n\r\n22\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([first, second]) = parser.parse(body, ct)
-  first.name |> should.equal(Some("a"))
-  first.body |> should.equal(<<"1":utf8>>)
-  second.name |> should.equal(Some("b"))
-  second.body |> should.equal(<<"22":utf8>>)
+  part.name(first) |> should.equal(Some("a"))
+  part.body(first) |> should.equal(<<"1":utf8>>)
+  part.name(second) |> should.equal(Some("b"))
+  part.body(second) |> should.equal(<<"22":utf8>>)
 }
 
 pub fn parse_file_part_with_content_type_test() {
@@ -36,10 +37,10 @@ pub fn parse_file_part_with_content_type_test() {
     1, 2, 3, "\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([file_part]) = parser.parse(body, ct)
-  file_part.name |> should.equal(Some("upload"))
-  file_part.filename |> should.equal(Some("a.bin"))
-  file_part.content_type |> should.equal(Some("application/octet-stream"))
-  file_part.body |> should.equal(<<1, 2, 3>>)
+  part.name(file_part) |> should.equal(Some("upload"))
+  part.filename(file_part) |> should.equal(Some("a.bin"))
+  part.content_type(file_part) |> should.equal(Some("application/octet-stream"))
+  part.body(file_part) |> should.equal(<<1, 2, 3>>)
 }
 
 pub fn parse_with_preamble_test() {
@@ -47,7 +48,7 @@ pub fn parse_with_preamble_test() {
     "ignored preamble\r\n--BOUNDARY\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nx\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.body |> should.equal(<<"x":utf8>>)
+  part.body(field_part) |> should.equal(<<"x":utf8>>)
 }
 
 pub fn parse_with_epilogue_test() {
@@ -55,7 +56,7 @@ pub fn parse_with_epilogue_test() {
     "--BOUNDARY\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nx\r\n--BOUNDARY--\r\nepilogue text":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.body |> should.equal(<<"x":utf8>>)
+  part.body(field_part) |> should.equal(<<"x":utf8>>)
 }
 
 pub fn parse_empty_body_part_test() {
@@ -63,8 +64,8 @@ pub fn parse_empty_body_part_test() {
     "--BOUNDARY\r\nContent-Disposition: form-data; name=\"empty\"\r\n\r\n\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.body |> should.equal(<<>>)
-  field_part.name |> should.equal(Some("empty"))
+  part.body(field_part) |> should.equal(<<>>)
+  part.name(field_part) |> should.equal(Some("empty"))
 }
 
 pub fn parse_empty_filename_is_a_file_test() {
@@ -72,9 +73,9 @@ pub fn parse_empty_filename_is_a_file_test() {
     "--BOUNDARY\r\nContent-Disposition: form-data; name=\"upload\"; filename=\"\"\r\n\r\n\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([file_part]) = parser.parse(body, ct)
-  file_part.name |> should.equal(Some("upload"))
-  file_part.filename |> should.equal(Some(""))
-  file_part.body |> should.equal(<<>>)
+  part.name(file_part) |> should.equal(Some("upload"))
+  part.filename(file_part) |> should.equal(Some(""))
+  part.body(file_part) |> should.equal(<<>>)
 }
 
 pub fn parse_immediate_close_returns_empty_test() {
@@ -88,8 +89,8 @@ pub fn parse_empty_header_block_with_blank_line_test() {
   // first delimiter terminator.
   let body = <<dash:utf8, "\r\nbody\r\n":utf8, close:utf8>>
   let assert Ok([the_part]) = parser.parse(body, ct)
-  the_part.headers |> should.equal([])
-  the_part.body |> should.equal(<<"body":utf8>>)
+  part.all_headers(the_part) |> should.equal([])
+  part.body(the_part) |> should.equal(<<"body":utf8>>)
 }
 
 pub fn parse_preserves_header_order_and_casing_test() {
@@ -97,7 +98,7 @@ pub fn parse_preserves_header_order_and_casing_test() {
     "--BOUNDARY\r\nX-Custom: 1\r\nContent-Disposition: form-data; name=\"a\"\r\nx-custom: 2\r\n\r\nbody\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.headers
+  part.all_headers(field_part)
   |> should.equal([
     #("X-Custom", "1"),
     #("Content-Disposition", "form-data; name=\"a\""),
@@ -111,7 +112,7 @@ pub fn parse_binary_body_is_byte_safe_test() {
     0, 0xFF, 0xFE, 0x80, 0x00, 0x0A, "\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([file_part]) = parser.parse(body, ct)
-  file_part.body |> should.equal(<<0, 0xFF, 0xFE, 0x80, 0x00, 0x0A>>)
+  part.body(file_part) |> should.equal(<<0, 0xFF, 0xFE, 0x80, 0x00, 0x0A>>)
 }
 
 pub fn parse_part_without_content_disposition_test() {
@@ -121,9 +122,9 @@ pub fn parse_part_without_content_disposition_test() {
     "--BOUNDARY\r\nX-Custom: 1\r\n\r\npayload\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([the_part]) = parser.parse(body, ct)
-  the_part.name |> should.equal(None)
-  the_part.filename |> should.equal(None)
-  the_part.body |> should.equal(<<"payload":utf8>>)
+  part.name(the_part) |> should.equal(None)
+  part.filename(the_part) |> should.equal(None)
+  part.body(the_part) |> should.equal(<<"payload":utf8>>)
 }
 
 pub fn parse_browser_style_payload_test() {
@@ -140,12 +141,12 @@ pub fn parse_browser_style_payload_test() {
     "------WebKitFormBoundary7MA4YWxkTrZu0gW--\r\n":utf8,
   >>
   let assert Ok([username_part, avatar_part]) = parser.parse(body, ct_value)
-  username_part.name |> should.equal(Some("username"))
-  username_part.body |> should.equal(<<"alice":utf8>>)
-  avatar_part.name |> should.equal(Some("avatar"))
-  avatar_part.filename |> should.equal(Some("face.png"))
-  avatar_part.content_type |> should.equal(Some("image/png"))
-  avatar_part.body
+  part.name(username_part) |> should.equal(Some("username"))
+  part.body(username_part) |> should.equal(<<"alice":utf8>>)
+  part.name(avatar_part) |> should.equal(Some("avatar"))
+  part.filename(avatar_part) |> should.equal(Some("face.png"))
+  part.content_type(avatar_part) |> should.equal(Some("image/png"))
+  part.body(avatar_part)
   |> should.equal(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>)
 }
 
@@ -156,7 +157,7 @@ pub fn parse_boundary_like_text_inside_body_test() {
     "--BOUNDARY\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nfoo --BOUNDARY in body\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.body |> should.equal(<<"foo --BOUNDARY in body":utf8>>)
+  part.body(field_part) |> should.equal(<<"foo --BOUNDARY in body":utf8>>)
 }
 
 pub fn parse_no_preceding_crlf_for_first_delimiter_test() {
@@ -167,5 +168,5 @@ pub fn parse_no_preceding_crlf_for_first_delimiter_test() {
     "--BOUNDARY\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nx\r\n--BOUNDARY--\r\n":utf8,
   >>
   let assert Ok([field_part]) = parser.parse(body, ct)
-  field_part.body |> should.equal(<<"x":utf8>>)
+  part.body(field_part) |> should.equal(<<"x":utf8>>)
 }

--- a/test/multipartkit/part_test.gleam
+++ b/test/multipartkit/part_test.gleam
@@ -1,9 +1,9 @@
 import gleam/option.{None, Some}
 import gleeunit/should
-import multipartkit/part.{type Part, Part}
+import multipartkit/part.{type Part}
 
 fn sample() -> Part {
-  Part(
+  part.new(
     headers: [
       #("Content-Disposition", "form-data; name=\"a\""),
       #("X-Trace", "first"),
@@ -38,7 +38,7 @@ pub fn header_lookup_uses_ascii_only_case_folding_test() {
   // Add a part with a header named like that and look up "x-custom-i"; they
   // must NOT match.
   let p =
-    Part(
+    part.new(
       headers: [#(dotless, "value")],
       name: None,
       filename: None,

--- a/test/multipartkit/query_test.gleam
+++ b/test/multipartkit/query_test.gleam
@@ -1,11 +1,11 @@
 import gleam/option.{None, Some}
 import gleeunit/should
 import multipartkit/error.{InvalidUtf8Field, MissingField, MissingFile}
-import multipartkit/part.{type Part, Part}
+import multipartkit/part.{type Part}
 import multipartkit/query
 
 fn text_part(name: String, body: BitArray) -> Part {
-  Part(
+  part.new(
     headers: [],
     name: Some(name),
     filename: None,
@@ -15,7 +15,7 @@ fn text_part(name: String, body: BitArray) -> Part {
 }
 
 fn file_part(name: String, filename: String, body: BitArray) -> Part {
-  Part(
+  part.new(
     headers: [],
     name: Some(name),
     filename: Some(filename),
@@ -25,7 +25,13 @@ fn file_part(name: String, filename: String, body: BitArray) -> Part {
 }
 
 fn anonymous_part(body: BitArray) -> Part {
-  Part(headers: [], name: None, filename: None, content_type: None, body: body)
+  part.new(
+    headers: [],
+    name: None,
+    filename: None,
+    content_type: None,
+    body: body,
+  )
 }
 
 pub fn field_returns_first_match_test() {
@@ -83,14 +89,14 @@ pub fn file_returns_first_match_test() {
     file_part("upload", "b.txt", <<"bye":utf8>>),
   ]
   let assert Some(found) = query.file(parts, "upload")
-  found.filename |> should.equal(Some("a.txt"))
+  part.filename(found) |> should.equal(Some("a.txt"))
 }
 
 pub fn file_includes_empty_filename_test() {
   // Spec: filename = Some("") still counts as a file (unselected file input).
   let parts = [file_part("upload", "", <<>>)]
   let assert Some(found) = query.file(parts, "upload")
-  found.filename |> should.equal(Some(""))
+  part.filename(found) |> should.equal(Some(""))
 }
 
 pub fn required_file_missing_test() {
@@ -106,8 +112,8 @@ pub fn files_returns_all_test() {
   let result = query.files(parts, "docs")
   case result {
     [first, second] -> {
-      first.filename |> should.equal(Some("a"))
-      second.filename |> should.equal(Some("b"))
+      part.filename(first) |> should.equal(Some("a"))
+      part.filename(second) |> should.equal(Some("b"))
     }
     _ -> should.fail()
   }

--- a/test/multipartkit/roundtrip_test.gleam
+++ b/test/multipartkit/roundtrip_test.gleam
@@ -2,20 +2,20 @@ import gleam/option.{None, Some}
 import gleeunit/should
 import multipartkit/encoder
 import multipartkit/parser
-import multipartkit/part.{Part}
+import multipartkit/part
 
 const ct = "multipart/form-data; boundary=ROUND"
 
 pub fn parse_then_encode_then_parse_test() {
   let parts = [
-    Part(
+    part.new(
       headers: [#("Content-Disposition", "form-data; name=\"a\"")],
       name: Some("a"),
       filename: None,
       content_type: None,
       body: <<"first":utf8>>,
     ),
-    Part(
+    part.new(
       headers: [
         #("Content-Disposition", "form-data; name=\"b\"; filename=\"f.bin\""),
         #("Content-Type", "application/octet-stream"),
@@ -33,7 +33,7 @@ pub fn parse_then_encode_then_parse_test() {
 
 pub fn encode_canonical_then_parse_byte_identical_test() {
   let parts = [
-    Part(
+    part.new(
       headers: [#("Content-Disposition", "form-data; name=\"a\"")],
       name: Some("a"),
       filename: None,
@@ -49,7 +49,7 @@ pub fn encode_canonical_then_parse_byte_identical_test() {
 
 pub fn empty_body_round_trip_test() {
   let parts = [
-    Part(
+    part.new(
       headers: [#("Content-Disposition", "form-data; name=\"empty\"")],
       name: Some("empty"),
       filename: None,

--- a/test/multipartkit/stream_test.gleam
+++ b/test/multipartkit/stream_test.gleam
@@ -7,7 +7,7 @@ import multipartkit/error.{
   InvalidContentType, MissingBoundary, PartTooLarge, UnexpectedEndOfInput,
   UnsupportedMediaType,
 }
-import multipartkit/limit.{Limits}
+import multipartkit/limit
 import multipartkit/stream
 
 const ct = "multipart/form-data; boundary=B"
@@ -66,8 +66,8 @@ pub fn parse_stream_yields_parts_test() {
   let items = drain_parts(stream_yielder)
   case items {
     [Ok(stream_part)] -> {
-      stream_part.name |> should.equal(Some("a"))
-      let assert Ok(body) = stream.drain_body(stream_part.body)
+      stream.name(stream_part) |> should.equal(Some("a"))
+      let assert Ok(body) = stream.drain_body(stream.body(stream_part))
       body |> should.equal(<<"hello":utf8>>)
     }
     _ -> should.fail()
@@ -81,8 +81,8 @@ pub fn parse_stream_handles_chunk_boundaries_test() {
   let assert Ok(stream_yielder) = stream.parse_stream(chunks, ct)
   case drain_parts(stream_yielder) {
     [Ok(stream_part)] -> {
-      stream_part.name |> should.equal(Some("a"))
-      let assert Ok(body_bytes) = stream.drain_body(stream_part.body)
+      stream.name(stream_part) |> should.equal(Some("a"))
+      let assert Ok(body_bytes) = stream.drain_body(stream.body(stream_part))
       body_bytes |> should.equal(<<"hello":utf8>>)
     }
     _ -> should.fail()
@@ -110,8 +110,8 @@ pub fn parse_stream_two_parts_in_input_order_test() {
   let assert Ok(stream_yielder) = stream.parse_stream(chunks, ct)
   case drain_parts(stream_yielder) {
     [Ok(p1), Ok(p2)] -> {
-      p1.name |> should.equal(Some("a"))
-      p2.name |> should.equal(Some("b"))
+      stream.name(p1) |> should.equal(Some("a"))
+      stream.name(p2) |> should.equal(Some("b"))
     }
     _ -> should.fail()
   }
@@ -129,10 +129,10 @@ pub fn parse_stream_skip_undrained_body_test() {
     |> list.filter_map(fn(item) { item })
   case items {
     [first, second] -> {
-      first.name |> should.equal(Some("a"))
-      second.name |> should.equal(Some("b"))
+      stream.name(first) |> should.equal(Some("a"))
+      stream.name(second) |> should.equal(Some("b"))
       // Now drain the second body — it should give "second".
-      let assert Ok(body_bytes) = stream.drain_body(second.body)
+      let assert Ok(body_bytes) = stream.drain_body(stream.body(second))
       body_bytes |> should.equal(<<"second":utf8>>)
     }
     _ -> should.fail()
@@ -153,11 +153,12 @@ pub fn parse_stream_pulls_chunks_lazily_test() {
   let assert Ok(stream_yielder) = stream.parse_stream(chunks, ct)
   case yielder.step(stream_yielder) {
     yielder.Next(Ok(first), rest) -> {
-      first.name |> should.equal(Some("a"))
+      stream.name(first) |> should.equal(Some("a"))
       // The remaining yielder should still produce part `b` after pulling
       // chunk_b on demand.
       case yielder.step(rest) {
-        yielder.Next(Ok(second), _) -> second.name |> should.equal(Some("b"))
+        yielder.Next(Ok(second), _) ->
+          stream.name(second) |> should.equal(Some("b"))
         _ -> should.fail()
       }
     }
@@ -175,8 +176,8 @@ pub fn parse_stream_body_too_large_caught_incrementally_test() {
   >>
   let huge = <<"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":utf8>>
   let chunks = yielder.from_list([chunk_a, chunk_b, huge])
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 30,
       max_part_bytes: 1000,
       max_parts: 100,
@@ -192,8 +193,8 @@ pub fn parse_stream_body_too_large_caught_incrementally_test() {
 
 pub fn parse_stream_with_limits_propagates_part_too_large_test() {
   let chunks = yielder.from_list([one_part_body()])
-  let limits =
-    Limits(
+  let assert Ok(limits) =
+    limit.new(
       max_body_bytes: 1000,
       max_part_bytes: 2,
       max_parts: 100,

--- a/test/multipartkit/validate_test.gleam
+++ b/test/multipartkit/validate_test.gleam
@@ -1,11 +1,11 @@
 import gleam/option.{type Option, None, Some}
 import gleeunit/should
 import multipartkit/error.{DisallowedContentType, PartTooLarge}
-import multipartkit/part.{type Part, Part}
+import multipartkit/part.{type Part}
 import multipartkit/validate
 
 fn build_part(name: String, ct: Option(String), body: BitArray) -> Part {
-  Part(
+  part.new(
     headers: [],
     name: Some(name),
     filename: None,

--- a/test/multipartkit_test.gleam
+++ b/test/multipartkit_test.gleam
@@ -3,6 +3,8 @@ import gleeunit
 import gleeunit/should
 import multipartkit
 import multipartkit/form
+import multipartkit/limit
+import multipartkit/part
 import multipartkit/query
 
 pub fn main() -> Nil {
@@ -23,20 +25,20 @@ pub fn facade_round_trip_test() {
   |> should.equal(Ok("hello"))
 
   let assert Ok(file_part) = query.required_file(parts, "avatar")
-  file_part.body
+  part.body(file_part)
   |> should.equal(<<1, 2, 3>>)
-  file_part.filename
+  part.filename(file_part)
   |> should.equal(Some("a.bin"))
 }
 
 pub fn default_limits_facade_test() {
   let limits = multipartkit.default_limits()
-  limits.max_body_bytes
+  limit.max_body_bytes(limits)
   |> should.equal(10_000_000)
-  limits.max_part_bytes
+  limit.max_part_bytes(limits)
   |> should.equal(5_000_000)
-  limits.max_parts
+  limit.max_parts(limits)
   |> should.equal(100)
-  limits.max_header_bytes
+  limit.max_header_bytes(limits)
   |> should.equal(16_384)
 }


### PR DESCRIPTION
## Summary

Mark `Limits`, `Part`, `StreamPart`, and `ContentDisposition` as `pub opaque type` so callers can no longer pattern-match on the raw constructor or read fields with dot notation. The representation is now free to evolve without breaking external consumers.

## Changes

- **`src/multipartkit/limit.gleam`**: `Limits` now `pub opaque`. The validated `limit.new(...)` builder and the `max_body_bytes/1` / `max_part_bytes/1` / `max_parts/1` / `max_header_bytes/1` accessors that already shipped in v0.3.0 become the only supported access paths.
- **`src/multipartkit/part.gleam`**: `Part` now `pub opaque`. New `part.new(headers:, name:, filename:, content_type:, body:)` constructor and `part.all_headers/1`, `part.name/1`, `part.filename/1`, `part.content_type/1`, `part.body/1` accessors. The existing case-insensitive `part.header/2` and `part.headers/2` helpers are unchanged. (`part.headers/2` keeps its name; `part.all_headers/1` is the new "all entries in input order" accessor — the names don't collide because they take different arities.)
- **`src/multipartkit/stream.gleam`**: `StreamPart` now `pub opaque`. New `stream.all_headers/1`, `stream.name/1`, `stream.filename/1`, `stream.content_type/1`, `stream.body/1` accessors. `stream.from_part`, `stream.parse_stream`, and `stream.drain_body` unchanged.
- **`src/multipartkit/content_disposition.gleam`**: `ContentDisposition` now `pub opaque`. New `disposition/1`, `name/1`, `filename/1`, `params/1` accessors.
- **Internal call sites** (`parser.gleam`, `encoder.gleam`, `form.gleam`, `query.gleam`, `validate.gleam`, `stream.gleam`, `internal/headers.gleam`) migrated to the new constructor / accessor surface — no behaviour changes.
- **Tests** (every test under `test/multipartkit/`) migrated to the same. Most still pattern-match the *outer* `Result` and bind the value, then call accessors instead of dotting into the bound variable.
- **README "Quick start"** and the four sample projects (`examples/quick_start`, `examples/parse_request`, `examples/streaming_parse`, `examples/mimetype_inference`) use the accessors so consumers copy-pasting from docs land on the supported surface.
- **CHANGELOG**: `[Unreleased] / Changed` entry tagged BREAKING with a complete migration table.

## Design Decisions

- **Field-by-field accessors over a single `to_record/1`**: matches what the rest of the package already does (`limit.max_body_bytes/1` shipped in v0.3.0 as part of the precursor work in #10), and lets callers inspect a single property without paying the cost of a fully-decoded record. Each accessor is one line of trivial code.
- **Constructor functions named `new` (or `make_decoded`-style internal helpers) rather than re-exporting `Limits` / `Part` / `StreamPart` constructors as aliases**: re-exporting would defeat the opacity by returning a value the caller can pattern-match against indirectly. The `new` form is the standard Gleam idiom and stays consistent with `form.new()`, `infer.default_inferer()`, etc.
- **`StreamPart` made opaque now even though #7 (chunked-body streaming) will reshape its body field**: closing the type ahead of #7 is the point. Once #7 lands, the body changes from "single-chunk yielder" to "multi-chunk yielder" — without opacity that would be a public-API break for any caller pattern-matching on `StreamPart`.
- **`part.all_headers/1` rather than `part.headers/1`**: the existing `part.headers/2` (`Part`, `String`) is the case-insensitive header lookup. Using `headers/1` for the raw list would shadow it confusingly. `all_headers/1` makes the relationship explicit.
- **No new error variants on `CodecError` / `MultipartError`**: callers that previously failed because they pattern-matched on the wrong constructor will now fail at compile time, which is the intended migration signal. A runtime error variant for "this type can't be constructed externally" would be redundant.

## Limitations

- **Breaking surface**: external callers that used `Limits(...)`, `Part(...)`, `StreamPart(...)`, `ContentDisposition(...)` constructors or `<value>.field` field access need to migrate to the new helpers. CHANGELOG documents the exact mapping.
- The `Form` builder (already opaque) and the `Inferer` callback record (intentionally a transparent function record) are unchanged.

Closes #8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Several core types (`Part`, `Limits`, `ContentDisposition`, `StreamPart`) are now opaque and cannot be directly accessed or constructed via traditional syntax.
  * Use dedicated construction and accessor functions to create and inspect these types instead of direct field access or constructor calls.
  * Updated documentation and examples reflect the new API patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->