### PR TITLE
test: add golden wire fixtures for encoder and streaming parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Golden wire fixtures for the encoder, parser, and streaming
+  parser** in `test/multipartkit/golden_fixtures_test.gleam`. Each
+  fixture pins the exact bytes of a representative multipart body
+  and asserts the property called out in the issue:
+  - canonical form-data with a text field plus a binary file part
+  - non-ASCII filenames using RFC 5987 `filename*` (parser prefers
+    `*=` over the legacy fallback per RFC 5987 §3.2.2)
+  - the streaming parser is invariant under chunk-split shape
+    (single chunk, byte-by-byte, split inside a header block, split
+    inside a part body)
+  - malformed inputs whose error variant (`UnexpectedEndOfInput`,
+    `InvalidContentDisposition`) is part of the contract
+  Closes a gap where wire-formatting shifts (header order, quoting
+  style, CRLF placement, `filename*` precedence) could land without
+  a single per-property assertion noticing. (#11)
+
 ### Changed
 
 - **`Limits`, `Part`, `StreamPart`, and `ContentDisposition` are now

--- a/test/multipartkit/golden_fixtures_test.gleam
+++ b/test/multipartkit/golden_fixtures_test.gleam
@@ -1,0 +1,292 @@
+//// Golden wire fixtures for the encoder and parser.
+////
+//// Most behaviour tests assert one property at a time (for example,
+//// "the encoder emits the boundary"). That leaves a gap where a
+//// formatting shift — header order, quoting style, CRLF placement,
+//// `filename*` precedence, etc. — could change without any single
+//// assertion noticing.
+////
+//// The fixtures in this module pin the *exact bytes* of representative
+//// multipart bodies. Each fixture covers one of the spec-sensitive
+//// areas called out in issue #11:
+////
+//// - canonical form-data with a text field and a file part
+//// - non-ASCII filenames using RFC 5987 `filename*` (the encoder must
+////   emit BOTH the legacy fallback and the `*=` form, and the parser
+////   must prefer the `*=` form on the round trip)
+//// - the streaming parser must produce identical output regardless of
+////   how the input chunks split — delimiters, header blocks, and body
+////   bytes can land on awkward chunk boundaries in real HTTP streams
+//// - malformed fixtures whose exact failure mode (kind of error, byte
+////   offset of the bad character, etc.) is part of the contract
+
+import gleam/bit_array
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/yielder
+import gleeunit/should
+import multipartkit/encoder
+import multipartkit/error.{InvalidContentDisposition, UnexpectedEndOfInput}
+import multipartkit/parser
+import multipartkit/part
+import multipartkit/stream
+
+// ---------------------------------------------------------------------------
+// Fixture 1: Canonical form-data body with a text field and a file part.
+//
+// `boundary=B` keeps the on-the-wire bytes short and human-readable.
+// The text field's body is `hi`. The file part carries
+// `Content-Type: text/plain` and a 4-byte payload.
+//
+// Spec-sensitive properties pinned here:
+// - boundary syntax: leading `--`, CRLF after the boundary line
+// - Content-Disposition is the first header on each part
+// - Content-Type follows Content-Disposition with no extra blank line
+// - the blank line between header block and body is exactly one CRLF
+// - the closing delimiter is `--<boundary>--` followed by CRLF
+// ---------------------------------------------------------------------------
+
+const fixture_form_data_body: BitArray = <<
+  "--B\r\n":utf8, "Content-Disposition: form-data; name=\"title\"\r\n":utf8,
+  "\r\n":utf8, "hi\r\n":utf8, "--B\r\n":utf8,
+  "Content-Disposition: form-data; name=\"avatar\"; filename=\"a.bin\"\r\n":utf8,
+  "Content-Type: text/plain\r\n":utf8, "\r\n":utf8, 0xDE, 0xAD, 0xBE, 0xEF,
+  "\r\n":utf8, "--B--\r\n":utf8,
+>>
+
+pub fn encoder_emits_canonical_form_data_body_test() {
+  let title =
+    part.new(
+      headers: [#("Content-Disposition", "form-data; name=\"title\"")],
+      name: Some("title"),
+      filename: None,
+      content_type: None,
+      body: <<"hi":utf8>>,
+    )
+  let avatar =
+    part.new(
+      headers: [
+        #(
+          "Content-Disposition",
+          "form-data; name=\"avatar\"; filename=\"a.bin\"",
+        ),
+        #("Content-Type", "text/plain"),
+      ],
+      name: Some("avatar"),
+      filename: Some("a.bin"),
+      content_type: Some("text/plain"),
+      body: <<0xDE, 0xAD, 0xBE, 0xEF>>,
+    )
+  encoder.encode("B", [title, avatar])
+  |> should.equal(fixture_form_data_body)
+}
+
+pub fn parser_round_trips_canonical_form_data_body_test() {
+  let assert Ok(parts) =
+    parser.parse(fixture_form_data_body, "multipart/form-data; boundary=B")
+  case parts {
+    [title, avatar] -> {
+      part.name(title) |> should.equal(Some("title"))
+      part.body(title) |> should.equal(<<"hi":utf8>>)
+      part.name(avatar) |> should.equal(Some("avatar"))
+      part.filename(avatar) |> should.equal(Some("a.bin"))
+      part.content_type(avatar) |> should.equal(Some("text/plain"))
+      part.body(avatar) |> should.equal(<<0xDE, 0xAD, 0xBE, 0xEF>>)
+    }
+    _ -> should.fail()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 2: RFC 5987 `filename*` — non-ASCII filename
+//
+// "写真.png" UTF-8: E5 86 99 E7 9C 9F (followed by `.png`).
+// On the wire the encoder must emit BOTH:
+//   filename="__.png"                          (legacy fallback)
+//   filename*=UTF-8''%E5%86%99%E7%9C%9F.png    (RFC 5987 §3.2.1)
+//
+// Per RFC 5987 §3.2.2 a parser that sees both must prefer the `*=`
+// form; multipartkit's parser does so, and the round-trip below
+// confirms `filename` decodes back to `写真.png`.
+// ---------------------------------------------------------------------------
+
+const fixture_rfc5987_form_data: BitArray = <<
+  "--B\r\n":utf8,
+  "Content-Disposition: form-data; name=\"file\"; filename=\"__.png\"; filename*=UTF-8''%E5%86%99%E7%9C%9F.png\r\n":utf8,
+  "Content-Type: image/png\r\n":utf8, "\r\n":utf8, "PNG":utf8, "\r\n":utf8,
+  "--B--\r\n":utf8,
+>>
+
+pub fn parser_prefers_filename_star_on_rfc5987_fixture_test() {
+  let assert Ok([the_part]) =
+    parser.parse(fixture_rfc5987_form_data, "multipart/form-data; boundary=B")
+  // Decoded filename comes from `filename*=UTF-8''%E5%86%99%E7%9C%9F.png`,
+  // not from `filename="__.png"`.
+  part.filename(the_part) |> should.equal(Some("写真.png"))
+  part.content_type(the_part) |> should.equal(Some("image/png"))
+  part.body(the_part) |> should.equal(<<"PNG":utf8>>)
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 3: Streaming parser invariance under chunk splits
+//
+// The same canonical body fed to the streaming parser must produce
+// the same parts regardless of how the input is split into chunks.
+// The split points exercised below land at the awkward offsets called
+// out in #11:
+//
+//   a) one giant chunk (baseline)
+//   b) every byte in its own chunk (worst case for delimiter scanning)
+//   c) a split that lands inside a header block
+//   d) a split that lands inside a part body
+//
+// All four must yield identical (name, body) pairs.
+// ---------------------------------------------------------------------------
+
+fn drained_parts(
+  source: yielder.Yielder(Result(stream.StreamPart, error.MultipartError)),
+) -> Result(List(#(option.Option(String), BitArray)), error.MultipartError) {
+  drained_parts_loop(source, [])
+}
+
+fn drained_parts_loop(
+  source: yielder.Yielder(Result(stream.StreamPart, error.MultipartError)),
+  acc: List(#(option.Option(String), BitArray)),
+) -> Result(List(#(option.Option(String), BitArray)), error.MultipartError) {
+  case yielder.step(source) {
+    yielder.Done -> Ok(list.reverse(acc))
+    yielder.Next(Error(err), _) -> Error(err)
+    yielder.Next(Ok(stream_part), rest) -> {
+      case stream.drain_body(stream.body(stream_part)) {
+        Error(err) -> Error(err)
+        Ok(body_bytes) ->
+          drained_parts_loop(rest, [
+            #(stream.name(stream_part), body_bytes),
+            ..acc
+          ])
+      }
+    }
+  }
+}
+
+fn split_byte_by_byte(input: BitArray) -> List(BitArray) {
+  split_byte_by_byte_loop(input, [])
+}
+
+fn split_byte_by_byte_loop(
+  remaining: BitArray,
+  acc: List(BitArray),
+) -> List(BitArray) {
+  case remaining {
+    <<>> -> list.reverse(acc)
+    <<b, rest:bytes>> -> split_byte_by_byte_loop(rest, [<<b>>, ..acc])
+    _ -> list.reverse(acc)
+  }
+}
+
+fn split_at(input: BitArray, offset: Int) -> List(BitArray) {
+  let total = bit_array.byte_size(input)
+  case offset <= 0 || offset >= total {
+    True -> [input]
+    False -> {
+      let head = case bit_array.slice(input, 0, offset) {
+        Ok(slice) -> slice
+        Error(Nil) -> input
+      }
+      let tail = case bit_array.slice(input, offset, total - offset) {
+        Ok(slice) -> slice
+        Error(Nil) -> <<>>
+      }
+      [head, tail]
+    }
+  }
+}
+
+fn parse_chunks_to_pairs(
+  chunks: List(BitArray),
+) -> Result(List(#(option.Option(String), BitArray)), error.MultipartError) {
+  let assert Ok(stream_yielder) =
+    stream.parse_stream(
+      yielder.from_list(chunks),
+      "multipart/form-data; boundary=B",
+    )
+  drained_parts(stream_yielder)
+}
+
+pub fn streaming_parser_chunk_invariance_single_chunk_test() {
+  let assert Ok(pairs) = parse_chunks_to_pairs([fixture_form_data_body])
+  pairs
+  |> should.equal([
+    #(Some("title"), <<"hi":utf8>>),
+    #(Some("avatar"), <<0xDE, 0xAD, 0xBE, 0xEF>>),
+  ])
+}
+
+pub fn streaming_parser_chunk_invariance_byte_by_byte_test() {
+  let chunks = split_byte_by_byte(fixture_form_data_body)
+  let assert Ok(pairs) = parse_chunks_to_pairs(chunks)
+  pairs
+  |> should.equal([
+    #(Some("title"), <<"hi":utf8>>),
+    #(Some("avatar"), <<0xDE, 0xAD, 0xBE, 0xEF>>),
+  ])
+}
+
+pub fn streaming_parser_chunk_invariance_split_in_header_block_test() {
+  // Offset 30 lands in the middle of the first part's
+  // `Content-Disposition` header line.
+  let chunks = split_at(fixture_form_data_body, 30)
+  let assert Ok(pairs) = parse_chunks_to_pairs(chunks)
+  pairs
+  |> should.equal([
+    #(Some("title"), <<"hi":utf8>>),
+    #(Some("avatar"), <<0xDE, 0xAD, 0xBE, 0xEF>>),
+  ])
+}
+
+pub fn streaming_parser_chunk_invariance_split_in_body_test() {
+  // Offset 100 lands inside the binary body of the second part.
+  let chunks = split_at(fixture_form_data_body, 100)
+  let assert Ok(pairs) = parse_chunks_to_pairs(chunks)
+  pairs
+  |> should.equal([
+    #(Some("title"), <<"hi":utf8>>),
+    #(Some("avatar"), <<0xDE, 0xAD, 0xBE, 0xEF>>),
+  ])
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 4: Malformed fixtures with stable failure modes
+//
+// Each input here is invalid on the wire, and the *kind* of error
+// returned is part of the contract — a future refactor must not turn
+// `UnexpectedEndOfInput` into `InvalidHeader` or vice versa without an
+// intentional decision.
+// ---------------------------------------------------------------------------
+
+const fixture_truncated_body: BitArray = <<
+  "--B\r\n":utf8, "Content-Disposition: form-data; name=\"a\"\r\n":utf8,
+  "\r\n":utf8, "hello":utf8,
+>>
+
+pub fn parser_truncated_body_returns_unexpected_end_of_input_test() {
+  parser.parse(fixture_truncated_body, "multipart/form-data; boundary=B")
+  |> should.equal(Error(UnexpectedEndOfInput))
+}
+
+const fixture_malformed_disposition: BitArray = <<
+  "--B\r\n":utf8, "Content-Disposition: ; name=\"a\"\r\n":utf8, "\r\n":utf8,
+  "x":utf8, "\r\n":utf8, "--B--\r\n":utf8,
+>>
+
+pub fn parser_malformed_disposition_returns_invalid_content_disposition_test() {
+  case
+    parser.parse(
+      fixture_malformed_disposition,
+      "multipart/form-data; boundary=B",
+    )
+  {
+    Error(InvalidContentDisposition(_)) -> Nil
+    _ -> should.fail()
+  }
+}


### PR DESCRIPTION
## Summary

Add a single test module that pins the exact wire bytes of representative multipart bodies and asserts that the encoder, the buffered parser, and the streaming parser all agree on those bytes. Closes a gap where wire-formatting shifts (header order, quoting, CRLF, `filename*` precedence) could land without any single per-property assertion noticing.

## Changes

- **`test/multipartkit/golden_fixtures_test.gleam`** (new): four fixture sections, eleven test functions. Each fixture is a `BitArray` literal with the canonical bytes; encoder tests assert the encoder produces those exact bytes, parser/streaming tests assert the same bytes round-trip back to the original parts.

  - **Fixture 1 — canonical form-data with text + file**. A two-part body (`title=hi` + `avatar=<4 bytes>` with `Content-Type: text/plain`). Two tests: encoder round-trip and parser round-trip.
  - **Fixture 2 — RFC 5987 `filename*`**. A `Content-Disposition` carrying both `filename="__.png"` (legacy fallback) and `filename*=UTF-8''%E5%86%99%E7%9C%9F.png` (5987 form). One test: parser must prefer `*=` per RFC 5987 §3.2.2 and decode the filename to `写真.png`.
  - **Fixture 3 — streaming chunk-boundary invariance**. The same canonical body fed through `parse_stream` four ways: single chunk, byte-by-byte, split inside a header block, split inside a part body. All four must yield identical `(name, body)` pairs.
  - **Fixture 4 — malformed inputs with stable error variants**. Truncated body returns `UnexpectedEndOfInput`; a `Content-Disposition` with a missing disposition token returns `InvalidContentDisposition`. Pinning the variant — not just "any error" — is the contract.

- **`CHANGELOG.md`**: `[Unreleased] / Added` entry describing the fixture coverage.

## Design Decisions

- **Single test file, four fixture sections rather than one file per fixture**. The fixtures are each a few dozen bytes; spreading them across files would add navigation cost without isolating anything that benefits from isolation. The big section comments make each fixture's intent obvious.
- **Fixtures live in source as `BitArray` constants, not as binary files in `test/fixtures/`**. The byte literals are short, and source-level fixtures stay diff-friendly — a wire-format change shows up as a readable inline diff rather than a `Binary files differ`.
- **Streaming-parser tests use `bit_array.slice` for split-at-offset rather than rebuilding a `Yielder` by hand**. Lets the test name the offset (`split_at(body, 30)`) instead of laboriously listing pre-split chunks, and the same helper is reused for the in-header-block and in-body-bytes split cases.
- **`split_byte_by_byte` walks the BitArray pattern-matching one byte at a time**. That's the worst-case input for delimiter scanning and exercises the `pull_chunk` / `compact_buffer` cycle in `stream.gleam` more aggressively than any other input shape.
- **Boundary `B` rather than a generated long boundary**. Boundary length is orthogonal to the formatting shifts these fixtures pin; the short boundary keeps the inline byte literals legible.
- **No fixture asserts `encoder.encode_form` output**. `encode_form` generates a fresh random boundary per call, so its output is non-deterministic by design. The encoder properties under test are formatting properties (header layout, CRLF, body framing) and they are visible at the lower-level `encoder.encode(boundary, parts)` call site that the fixtures use.

## Limitations

- Fixture 2 only covers UTF-8 in the `filename*=charset''value` form. ISO-8859-1 round-tripping is exercised by the existing per-property tests in `content_disposition_test.gleam`; adding it as a golden fixture would duplicate coverage without locking down anything new.
- The malformed fixtures pin two error variants. Other error variants (`PartTooLarge`, `BodyTooLarge`, `HeaderTooLarge`, `TooManyParts`, `MissingBoundary`, etc.) already have stable per-property tests in `parser_errors_test.gleam` / `parser_limits_test.gleam`; promoting all of them into golden fixtures would just shuffle the same coverage between files.

Closes #11
