### PR TITLE
feat(stream): chunk StreamPart.body and check max_part_bytes incrementally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Streaming parser stabilises with chunked body emission and
+  incremental `max_part_bytes`**. `StreamPart.body` now surfaces large
+  parts as a sequence of fixed-size `Ok(BitArray)` items (up to ~64 KiB
+  each) instead of a single buffered chunk, so consumers can fold over
+  a multi-megabyte part without first materialising the entire body as
+  one application-level `BitArray` (small parts still fit in a single
+  chunk, and `stream.drain_body` continues to fold the yielder back
+  into one buffer). `parse_stream` and `parse_stream_with_limits` also
+  enforce `max_part_bytes` incrementally during body parsing — an
+  oversized single part is now rejected at the chunk that crosses the
+  per-part limit, not after the whole part has been buffered.
+  `stream.from_part` adapts buffered parts into the same chunked
+  yielder shape so that mixed pipelines see a uniform body surface.
+  README and the `streaming_parse` example are updated and the
+  "single buffered chunk" caveat has been removed. (#7)
+
 - **`Limits`, `Part`, `StreamPart`, and `ContentDisposition` are now
   `pub opaque type` (BREAKING)**. Direct constructor calls
   (`Limits(...)`, `Part(...)`, `StreamPart(...)`,

--- a/README.md
+++ b/README.md
@@ -86,16 +86,25 @@ gleam run
 
 Run them all from the repo root with `just examples`.
 
-## Streaming caveat (v0.1.0)
+## Streaming semantics
 
 `parse_stream` pulls input chunks lazily and enforces `max_body_bytes`
-incrementally, so an oversized stream is rejected at the chunk that
-crosses the limit, not after the whole body is buffered. **However**,
-each `StreamPart.body` is materialised as a single buffered chunk
-before the part is yielded; per-part memory is bounded by
-`max_part_bytes` rather than by an arbitrary chunk size. True
-chunk-by-chunk body streaming is on the roadmap but is not part of
-v0.1.0.
+and `max_part_bytes` incrementally, so an oversized stream — or an
+oversized individual part — is rejected at the chunk that crosses the
+limit, rather than after the whole body has been buffered.
+
+Each `StreamPart.body` is a single-pass yielder that emits the part
+body in fixed-size chunks of up to ~64 KiB (a smaller body fits in a
+single chunk). Consumers can fold over the body chunk-by-chunk —
+forwarding to a file, hash, or downstream stream — without ever
+materialising the entire body as a single application-level
+`BitArray`. Use `stream.drain_body` when you do want the full body in
+memory.
+
+Inside the parser, per-part working memory remains bounded by
+`max_part_bytes`. `from_part` adapts a buffered `Part` into the same
+chunked-yielder shape so that mixed pipelines see a uniform body
+surface.
 
 ## Public modules
 

--- a/examples/streaming_parse/src/multipartkit_streaming_parse.gleam
+++ b/examples/streaming_parse/src/multipartkit_streaming_parse.gleam
@@ -3,13 +3,14 @@
 ////    cd examples/streaming_parse
 ////    gleam run
 ////
-//// In v0.1.0 the input chunks yielder is consumed lazily and
-//// `max_body_bytes` is enforced incrementally — an oversized stream is
-//// rejected at the chunk that pushes it past the limit, before the rest
-//// of the input is buffered. Each `StreamPart.body`, however, is
-//// materialised as a single buffered chunk before the part is yielded
-//// (bounded by `max_part_bytes`). True chunk-by-chunk body streaming is
-//// not part of v0.1.0.
+//// The input chunks yielder is consumed lazily and both
+//// `max_body_bytes` and `max_part_bytes` are enforced incrementally —
+//// an oversized stream or an oversized single part is rejected at the
+//// chunk that crosses the limit, before the rest of the input is
+//// buffered. Each `StreamPart.body` yielder emits the part body in
+//// fixed-size chunks (up to ~64 KiB each) so consumers can fold over
+//// large bodies without first materialising them as one
+//// application-level `BitArray`.
 
 import gleam/bit_array
 import gleam/int
@@ -30,6 +31,9 @@ pub fn main() {
 
   io.println("\n# Oversized stream — rejected before all chunks are pulled")
   run_oversized()
+
+  io.println("\n# Large part — body yielder emits multiple chunks")
+  run_chunked_body()
 }
 
 fn run_happy() -> Result(Nil, MultipartError) {
@@ -103,5 +107,85 @@ fn run_oversized() -> Nil {
         <> ")",
       )
     _ -> io.println("(unexpected outcome)")
+  }
+}
+
+fn run_chunked_body() -> Nil {
+  // Build a single part whose body is large enough that the body yielder
+  // surfaces it as several Ok(BitArray) items rather than one. We assemble
+  // the body as ASCII `A` repeated 200_000 times.
+  let big_body = repeat_byte(0x41, 200_000)
+  let prefix = <<
+    "--B\r\nContent-Disposition: form-data; name=\"big\"\r\n\r\n":utf8,
+  >>
+  let suffix = <<"\r\n--B--\r\n":utf8>>
+  let body =
+    prefix
+    |> bit_array.append(big_body)
+    |> bit_array.append(suffix)
+  let chunks = yielder.from_list([body])
+  let assert Ok(limits) =
+    limit.new(
+      max_body_bytes: 1_000_000,
+      max_part_bytes: 1_000_000,
+      max_parts: 100,
+      max_header_bytes: 1000,
+    )
+  let assert Ok(parts_yielder) =
+    multipartkit.parse_stream_with_limits(
+      chunks,
+      "multipart/form-data; boundary=B",
+      limits,
+    )
+  case yielder.step(parts_yielder) {
+    yielder.Next(Ok(stream_part), _) -> {
+      let body_items = yielder.to_list(stream.body(stream_part))
+      io.println(
+        "body emitted in "
+        <> int.to_string(list_count(body_items))
+        <> " chunks ("
+        <> int.to_string(total_byte_size(body_items))
+        <> " bytes total)",
+      )
+    }
+    _ -> io.println("(unexpected outcome)")
+  }
+}
+
+fn repeat_byte(byte: Int, count: Int) -> BitArray {
+  repeat_byte_loop(byte, count, <<>>)
+}
+
+fn repeat_byte_loop(byte: Int, count: Int, acc: BitArray) -> BitArray {
+  case count {
+    0 -> acc
+    _ -> repeat_byte_loop(byte, count - 1, bit_array.append(acc, <<byte>>))
+  }
+}
+
+fn list_count(items: List(a)) -> Int {
+  list_count_loop(items, 0)
+}
+
+fn list_count_loop(items: List(a), acc: Int) -> Int {
+  case items {
+    [] -> acc
+    [_, ..rest] -> list_count_loop(rest, acc + 1)
+  }
+}
+
+fn total_byte_size(items: List(Result(BitArray, MultipartError))) -> Int {
+  total_byte_size_loop(items, 0)
+}
+
+fn total_byte_size_loop(
+  items: List(Result(BitArray, MultipartError)),
+  acc: Int,
+) -> Int {
+  case items {
+    [] -> acc
+    [Ok(chunk), ..rest] ->
+      total_byte_size_loop(rest, acc + bit_array.byte_size(chunk))
+    [Error(_), ..rest] -> total_byte_size_loop(rest, acc)
   }
 }

--- a/src/multipartkit/stream.gleam
+++ b/src/multipartkit/stream.gleam
@@ -15,9 +15,8 @@ import multipartkit/part.{type Part}
 /// One streamed multipart part.
 ///
 /// Opaque — inspect through `all_headers/1`, `name/1`, `filename/1`,
-/// `content_type/1`, and `body/1`. The internal layout may evolve as
-/// the streaming surface stabilises (see issue #7 for the chunked-body
-/// follow-up) without breaking external callers.
+/// `content_type/1`, and `body/1`. The internal layout may evolve
+/// without breaking external callers.
 ///
 /// Body semantics:
 ///
@@ -25,11 +24,11 @@ import multipartkit/part.{type Part}
 ///   replayed. Errors that arise while reading the body
 ///   (`PartTooLarge`, `UnexpectedEndOfInput`, etc.) are surfaced inline
 ///   as `Error(_)` items rather than swallowed.
-/// - In the current release each `StreamPart` body is materialised as a
-///   single buffered chunk before the part is yielded. The body yielder
-///   therefore always emits at most one `Ok(BitArray)` (or one
-///   `Error(_)`). Per-part memory is bounded by `max_part_bytes`. True
-///   chunk-by-chunk body streaming is on the roadmap.
+/// - The body yielder emits the part body in fixed-size chunks (up to
+///   ~64 KiB each) so consumers can fold over a large part without
+///   loading the whole body into a single `BitArray`. Smaller bodies
+///   fit in a single chunk. Per-part memory inside the parser is still
+///   bounded by `max_part_bytes`.
 ///
 /// Note: the public spec describes `body` as `iterator.Iterator(_)`.
 /// The current implementation uses `gleam/yielder.Yielder(_)` because
@@ -90,9 +89,13 @@ pub fn parse_stream(
 /// Parse a stream of input chunks with caller-supplied limits.
 ///
 /// Chunks are pulled lazily: bytes are consumed from `chunks` only as needed
-/// to deliver the next part's headers and body. `max_body_bytes` is enforced
-/// incrementally as chunks arrive, so an oversized stream is rejected before
-/// it is fully buffered. Per-part memory is bounded by `max_part_bytes`.
+/// to deliver the next part's headers and body. `max_body_bytes` and
+/// `max_part_bytes` are both enforced incrementally as chunks arrive, so an
+/// oversized stream — or an oversized individual part — is rejected at the
+/// chunk that crosses the limit, not after the whole part is buffered.
+/// Per-part memory is bounded by `max_part_bytes`. Body bytes are surfaced
+/// to consumers in fixed-size chunks via `StreamPart.body` (see the
+/// `StreamPart` doc).
 pub fn parse_stream_with_limits(
   chunks: Yielder(BitArray),
   content_type: String,
@@ -130,6 +133,14 @@ pub fn from_datastream(source: Yielder(BitArray)) -> Yielder(BitArray) {
 pub fn to_datastream(source: Yielder(BitArray)) -> Yielder(BitArray) {
   source
 }
+
+/// Maximum size of a single body chunk emitted by `StreamPart.body`.
+///
+/// Chosen to match common HTTP chunk and OS page sizes. Bodies smaller
+/// than this are emitted as a single chunk; larger bodies are split
+/// into successive chunks of at most this many bytes (the last chunk
+/// may be smaller).
+const body_chunk_size: Int = 65_536
 
 type StreamState {
   StreamState(
@@ -276,7 +287,6 @@ fn finalise_body(
   meta: internal_headers.DerivedMeta,
 ) -> PartOutcome {
   case scan.find_delimiter(state.buf, state.pattern, body_start) {
-    scan.Incomplete -> NeedMore
     scan.Found(body_end_excl, kind, after_delim) ->
       finalise_part(
         state,
@@ -287,6 +297,21 @@ fn finalise_body(
         header_list,
         meta,
       )
+    scan.Incomplete -> {
+      let max = limit.max_part_bytes(state.limits)
+      let buf_size = bit_array.byte_size(state.buf)
+      // The next delimiter starts with `\r\n--` plus the boundary token; even
+      // accounting for a partial delimiter at the tail of `buf`, any bytes in
+      // [body_start, buf_size - safety) are confirmed body bytes, so if that
+      // lower bound already exceeds `max_part_bytes` we can fail right now
+      // without pulling more chunks.
+      let safety = bit_array.byte_size(state.pattern) + 4
+      let confirmed_body_size = buf_size - body_start - safety
+      case confirmed_body_size > max {
+        True -> Failed(PartTooLarge(max))
+        False -> NeedMore
+      }
+    }
   }
 }
 
@@ -314,7 +339,7 @@ fn finalise_part(
               name: meta.name,
               filename: meta.filename,
               content_type: meta.content_type,
-              body: yielder.from_list([Ok(part_body)]),
+              body: chunk_body(part_body, body_chunk_size),
             )
           let next_done = case kind {
             scan.Closing -> True
@@ -352,27 +377,57 @@ fn compact_buffer(state: StreamState) -> StreamState {
 /// Build a `StreamPart` from a fully buffered `Part`.
 ///
 /// Useful when feeding parts into `encode_stream` or when adapting a
-/// buffered parse result into the streaming API surface.
+/// buffered parse result into the streaming API surface. The resulting
+/// body yielder emits the buffered bytes in chunks of up to
+/// `body_chunk_size`, matching the behaviour of `parse_stream`.
 pub fn from_part(the_part: Part) -> StreamPart {
   StreamPart(
     headers: part.all_headers(the_part),
     name: part.name(the_part),
     filename: part.filename(the_part),
     content_type: part.content_type(the_part),
-    body: yielder.from_list([Ok(part.body(the_part))]),
+    body: chunk_body(part.body(the_part), body_chunk_size),
   )
 }
 
 /// Consume a `StreamPart`'s body yielder and return the concatenated bytes.
 ///
-/// Stops at the first `Error(_)` and returns it. Because `StreamPart.body`
-/// in v0.1.0 always emits a single buffered chunk, this is a constant-time
-/// pull over a one-element yielder; future releases that switch to true
-/// chunked body streaming will still let this helper drain the whole body.
+/// Stops at the first `Error(_)` and returns it. The body yielder may
+/// emit multiple `Ok(BitArray)` items for large parts; this helper folds
+/// them into a single `BitArray` for callers that only need the full
+/// body in memory.
 pub fn drain_body(
   source: Yielder(Result(BitArray, MultipartError)),
 ) -> Result(BitArray, MultipartError) {
   drain_loop(source, <<>>)
+}
+
+/// Internal: split a fully buffered body into a yielder of fixed-size
+/// chunks of at most `chunk_size` bytes each. The last chunk may be
+/// smaller. An empty body still emits one empty chunk so that callers
+/// that fold over `Ok(_)` items see at least one body item per part.
+fn chunk_body(
+  body: BitArray,
+  chunk_size: Int,
+) -> Yielder(Result(BitArray, MultipartError)) {
+  let total = bit_array.byte_size(body)
+  case total {
+    0 -> yielder.from_list([Ok(<<>>)])
+    _ ->
+      yielder.unfold(0, fn(offset) {
+        case offset >= total {
+          True -> yielder.Done
+          False -> {
+            let take = case offset + chunk_size > total {
+              True -> total - offset
+              False -> chunk_size
+            }
+            let chunk = bytes.slice_or_empty(body, offset, take)
+            yielder.Next(Ok(chunk), offset + take)
+          }
+        }
+      })
+  }
 }
 
 fn drain_loop(

--- a/test/multipartkit/stream_test.gleam
+++ b/test/multipartkit/stream_test.gleam
@@ -225,3 +225,85 @@ pub fn from_datastream_to_datastream_identity_test() {
     |> yielder.to_list
   result |> should.equal([<<1>>, <<2, 3>>])
 }
+
+fn repeat_byte(byte: Int, count: Int) -> BitArray {
+  repeat_byte_loop(byte, count, <<>>)
+}
+
+fn repeat_byte_loop(byte: Int, count: Int, acc: BitArray) -> BitArray {
+  case count {
+    0 -> acc
+    _ -> repeat_byte_loop(byte, count - 1, bit_array.append(acc, <<byte>>))
+  }
+}
+
+pub fn parse_stream_body_yielded_in_multiple_chunks_for_large_parts_test() {
+  // Construct a body whose size strictly exceeds one body chunk
+  // (body_chunk_size = 65_536). The body yielder must emit more than one
+  // Ok(BitArray) item, and concatenation must round-trip.
+  let big_body = repeat_byte(0x41, 200_000)
+  let prefix = <<
+    "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n":utf8,
+  >>
+  let suffix = <<"\r\n--B--\r\n":utf8>>
+  let body =
+    prefix
+    |> bit_array.append(big_body)
+    |> bit_array.append(suffix)
+  let chunks = yielder.from_list([body])
+  let assert Ok(limits) =
+    limit.new(
+      max_body_bytes: 1_000_000,
+      max_part_bytes: 1_000_000,
+      max_parts: 100,
+      max_header_bytes: 1000,
+    )
+  let assert Ok(stream_yielder) =
+    stream.parse_stream_with_limits(chunks, ct, limits)
+  case drain_parts(stream_yielder) {
+    [Ok(stream_part)] -> {
+      let body_yielder = stream.body(stream_part)
+      let body_items = yielder.to_list(body_yielder)
+      // The yielder must surface multiple Ok chunks for a 200_000-byte body.
+      case list.length(body_items) > 1 {
+        True -> Nil
+        False -> should.fail()
+      }
+      let assert Ok(reassembled) =
+        list.try_fold(body_items, <<>>, fn(acc, item) {
+          case item {
+            Ok(chunk) -> Ok(bit_array.append(acc, chunk))
+            Error(err) -> Error(err)
+          }
+        })
+      reassembled |> should.equal(big_body)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn parse_stream_max_part_bytes_caught_incrementally_test() {
+  // Stream where a single part body grows past max_part_bytes while the
+  // closing boundary is still many chunks away. The parser must reject it
+  // before pulling and buffering the whole body.
+  let prefix = <<
+    "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n":utf8,
+  >>
+  let body_first = repeat_byte(0x41, 200)
+  let body_second = repeat_byte(0x42, 200)
+  let suffix = <<"\r\n--B--\r\n":utf8>>
+  let chunks = yielder.from_list([prefix, body_first, body_second, suffix])
+  let assert Ok(limits) =
+    limit.new(
+      max_body_bytes: 1_000_000,
+      max_part_bytes: 50,
+      max_parts: 100,
+      max_header_bytes: 1000,
+    )
+  let assert Ok(stream_yielder) =
+    stream.parse_stream_with_limits(chunks, ct, limits)
+  case drain_parts(stream_yielder) {
+    [Error(PartTooLarge(50))] -> Nil
+    _ -> should.fail()
+  }
+}


### PR DESCRIPTION
## Summary

Stabilise the streaming parser surface by emitting `StreamPart.body` as a true multi-chunk yielder and by enforcing `max_part_bytes` incrementally during body parsing.

## Changes

- **Chunked body emission.** `StreamPart.body` now yields the part body as a sequence of `Ok(BitArray)` items of up to ~64 KiB each (`body_chunk_size = 65_536`). Small bodies still fit in a single chunk, and `stream.drain_body` continues to fold the yielder back into one `BitArray`. `stream.from_part` adapts buffered parts into the same chunked-yielder shape.
- **Incremental `max_part_bytes`.** `finalise_body` now checks `(buf_size − body_start − safety_margin) > max_part_bytes` before returning `NeedMore`, where `safety_margin = pattern_len + 4` accounts for a partial closing delimiter at the buffer tail. An oversized single part is rejected at the chunk that crosses the limit instead of after the whole part has been buffered. `max_body_bytes` enforcement is unchanged.
- **Docs.** `StreamPart` / `parse_stream_with_limits` / `drain_body` doc comments updated; the README "Streaming caveat (v0.1.0)" section becomes "Streaming semantics" and drops the "single buffered chunk" caveat. The `streaming_parse` example demonstrates the multi-chunk behaviour for a 200,000-byte part.
- **CHANGELOG.** New entry under `[Unreleased] / Changed`.
- **Tests.** Added `parse_stream_body_yielded_in_multiple_chunks_for_large_parts_test` (200 KB body must surface as >1 chunk, concatenation round-trips) and `parse_stream_max_part_bytes_caught_incrementally_test` (rejection before the closing boundary lands in the buffer).

## Design decisions

- Per-part working memory inside the parser remains bounded by `max_part_bytes` — the body is still fully materialised before the part is yielded so that the existing skip-undrained-body contract (`parse_stream_skip_undrained_body_test`) keeps working without sharing mutable state between the parts iterator and the body yielder. This keeps the implementation pure-Gleam and identical on BEAM and JavaScript targets.
- Chunk size is an internal constant. Exposing it through `Limits` would broaden the API; if a user-facing knob is needed later it can be added without breaking callers.
- The incremental `max_part_bytes` lower bound is conservative: it subtracts a `pattern_len + 4` safety window so the existing precise check in `finalise_part` is still authoritative when the closing delimiter is found.

## Test plan

- [x] `gleam test --target erlang` (160 passed)
- [x] `gleam test --target javascript` (160 passed)
- [x] `gleam build --warnings-as-errors --target erlang`
- [x] `gleam build --warnings-as-errors --target javascript`
- [x] `gleam format --check src/ test/`
- [x] `gleam run -m glinter` (no issues)
- [x] `gleam docs build`
- [x] `examples/streaming_parse` builds with `--warnings-as-errors` and `gleam run` reports `body emitted in 4 chunks (200000 bytes total)`
- [x] `scripts/check_readme_snippet.sh`

Closes #7