### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-30
+
 ### Added
 
 - **Golden wire fixtures for the encoder, parser, and streaming

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.3.0"
+version = "0.4.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Added

- **Golden wire fixtures for the encoder, parser, and streaming
  parser** in `test/multipartkit/golden_fixtures_test.gleam`. Each
  fixture pins the exact bytes of a representative multipart body
  and asserts the property called out in the issue:
  - canonical form-data with a text field plus a binary file part
  - non-ASCII filenames using RFC 5987 `filename*` (parser prefers
    `*=` over the legacy fallback per RFC 5987 §3.2.2)
  - the streaming parser is invariant under chunk-split shape
    (single chunk, byte-by-byte, split inside a header block, split
    inside a part body)
  - malformed inputs whose error variant (`UnexpectedEndOfInput`,
    `InvalidContentDisposition`) is part of the contract
  Closes a gap where wire-formatting shifts (header order, quoting
  style, CRLF placement, `filename*` precedence) could land without
  a single per-property assertion noticing. (#11)

### Changed

- **Streaming parser stabilises with chunked body emission and
  incremental `max_part_bytes`**. `StreamPart.body` now surfaces large
  parts as a sequence of fixed-size `Ok(BitArray)` items (up to ~64 KiB
  each) instead of a single buffered chunk, so consumers can fold over
  a multi-megabyte part without first materialising the entire body as
  one application-level `BitArray` (small parts still fit in a single
  chunk, and `stream.drain_body` continues to fold the yielder back
  into one buffer). `parse_stream` and `parse_stream_with_limits` also
  enforce `max_part_bytes` incrementally during body parsing — an
  oversized single part is now rejected at the chunk that crosses the
  per-part limit, not after the whole part has been buffered.
  `stream.from_part` adapts buffered parts into the same chunked
  yielder shape so that mixed pipelines see a uniform body surface.
  README and the `streaming_parse` example are updated and the
  "single buffered chunk" caveat has been removed. (#7)

- **`Limits`, `Part`, `StreamPart`, and `ContentDisposition` are now
  `pub opaque type` (BREAKING)**. Direct constructor calls
  (`Limits(...)`, `Part(...)`, `StreamPart(...)`,
  `ContentDisposition(...)`) and field-access expressions
  (`limits.max_body_bytes`, `the_part.body`, `parsed.disposition`,
  etc.) no longer compile from outside the defining module. The
  representation can now evolve without breaking external pattern
  matches. Migration paths:

  - `Limits` — construct with `limit.new(max_body_bytes:,
    max_part_bytes:, max_parts:, max_header_bytes:)` (returns
    `Result(Limits, LimitConfigError)`) or `limit.default_limits()`.
    Read fields via the `limit.max_body_bytes/1`,
    `limit.max_part_bytes/1`, `limit.max_parts/1`, and
    `limit.max_header_bytes/1` accessors that already shipped in
    v0.3.0.
  - `Part` — construct with `part.new(headers:, name:, filename:,
    content_type:, body:)`. Read fields via `part.all_headers/1`,
    `part.name/1`, `part.filename/1`, `part.content_type/1`, and
    `part.body/1`. The existing `part.header/2` and `part.headers/2`
    case-insensitive header lookups are unchanged.
  - `StreamPart` — receive from `stream.parse_stream` /
    `stream.from_part`; inspect via `stream.all_headers/1`,
    `stream.name/1`, `stream.filename/1`, `stream.content_type/1`,
    and `stream.body/1`.
  - `ContentDisposition` — receive from
    `content_disposition.parse/1`; inspect via
    `content_disposition.disposition/1`,
    `content_disposition.name/1`, `content_disposition.filename/1`,
    and `content_disposition.params/1`.

  README and examples are updated to use the accessors. (#8)
