### PR TITLE
docs(readme): keep non-streaming install single-line, defer gleam_yielder

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,9 @@ target: `multipart/form-data`. Secondary: `multipart/mixed` and
 gleam add multipartkit
 ```
 
-For the streaming API you also need
-[`gleam_yielder`](https://hex.pm/packages/gleam_yielder):
-
-```sh
-gleam add gleam_yielder
-```
+That is all the non-streaming API needs. The streaming parser pulls in
+one extra package; see [Streaming semantics](#streaming-semantics) for
+the install step and the wiring.
 
 ## Quick start
 
@@ -87,6 +84,14 @@ gleam run
 Run them all from the repo root with `just examples`.
 
 ## Streaming semantics
+
+The streaming parser is opt-in. Add it to your project only when you
+need chunk-at-a-time parsing — the normal full-body API in the Quick
+start above does not depend on it.
+
+```sh
+gleam add gleam_yielder
+```
 
 `parse_stream` pulls input chunks lazily and enforces `max_body_bytes`
 and `max_part_bytes` incrementally, so an oversized stream — or an

--- a/src/multipartkit/query.gleam
+++ b/src/multipartkit/query.gleam
@@ -17,14 +17,8 @@ import multipartkit/part.{type Part}
 /// `None` is returned. Use `required_field` if you need to distinguish
 /// "missing" from "present but not UTF-8".
 pub fn field(parts: List(Part), name: String) -> Option(String) {
-  case find_text_field(parts, name) {
-    None -> None
-    Some(found_part) ->
-      case bit_array.to_string(part.body(found_part)) {
-        Ok(value) -> Some(value)
-        Error(Nil) -> None
-      }
-  }
+  required_field(parts, name)
+  |> option.from_result
 }
 
 /// Strict variant of `field`. Returns `MissingField` if no text field


### PR DESCRIPTION
## Summary

- `gleam add multipartkit` is the only step on the main install path now. The extra `gleam add gleam_yielder` line moved into the streaming-specific section where it is actually needed.
- Folded `query.field` through `query.required_field` so the find-then-utf8-decode logic only exists once.

## Changes

- `README.md`: install snippet is single-line; the Streaming semantics section now opens with the `gleam add gleam_yielder` install step before the existing prose.
- `src/multipartkit/query.gleam`: `field` now wraps `required_field` and pipes the `Result` through `option.from_result` (keeping glinter's `thrown_away_error` rule happy).

`file` / `required_file` already share their lookup via `required_file` calling `file`, so they were left alone.

## Test plan

- `just all` — clean + deps + format-check + glinter + Erlang/JS check + Erlang/JS build with --warnings-as-errors + Erlang/JS test + docs build + all four examples. 160 / 160 tests pass on both targets; every example runs to completion.

Closes #18