### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-04
+
+### Documentation
+
+- **readme**: `gleam add multipartkit` is the only step on the main
+  install path now. The extra `gleam add gleam_yielder` line moved into
+  the streaming-specific section, where it is actually needed. (#18)
+
+### Changed
+
+- **query**: `query.field` now wraps `query.required_field` so the
+  find-the-text-field-and-decode-utf8 logic only exists once. The
+  result is funneled through `option.from_result` to satisfy glinter's
+  `thrown_away_error` rule. Public behavior unchanged. (#18)
+
 ## [0.4.0] - 2026-04-30
 
 ### Added

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.4.0"
+version = "0.5.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Documentation

- **readme**: `gleam add multipartkit` is the only step on the main
  install path now. The extra `gleam add gleam_yielder` line moved into
  the streaming-specific section, where it is actually needed. (#18)

### Changed

- **query**: `query.field` now wraps `query.required_field` so the
  find-the-text-field-and-decode-utf8 logic only exists once. The
  result is funneled through `option.from_result` to satisfy glinter's
  `thrown_away_error` rule. Public behavior unchanged. (#18)
