### PR TITLE
docs(readme): show part.body in Quick start so users find the byte payload accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **readme**: extend the Quick start snippet with `part.body(avatar)` and
+  print the byte size of the parsed file part. New users no longer have
+  to grep `multipartkit/part` to find the BitArray accessor. The
+  `examples/quick_start` source is updated in lockstep so the
+  README/example byte-equality check still passes. (#21)
+
 ## [0.5.0] - 2026-05-04
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ copy it into `src/main.gleam`, run `gleam add multipartkit`, then
 `gleam run`.
 
 ```gleam
+import gleam/bit_array
+import gleam/int
 import gleam/io
 import gleam/option.{None, Some}
 import multipartkit
@@ -61,6 +63,8 @@ pub fn main() {
     Some(filename) -> io.println("avatar filename=" <> filename)
     None -> io.println("avatar has no filename")
   }
+  let avatar_bytes = part.body(avatar)
+  io.println("avatar size=" <> int.to_string(bit_array.byte_size(avatar_bytes)))
 }
 ```
 

--- a/examples/quick_start/src/multipartkit_quick_start.gleam
+++ b/examples/quick_start/src/multipartkit_quick_start.gleam
@@ -1,3 +1,5 @@
+import gleam/bit_array
+import gleam/int
 import gleam/io
 import gleam/option.{None, Some}
 import multipartkit
@@ -23,4 +25,6 @@ pub fn main() {
     Some(filename) -> io.println("avatar filename=" <> filename)
     None -> io.println("avatar has no filename")
   }
+  let avatar_bytes = part.body(avatar)
+  io.println("avatar size=" <> int.to_string(bit_array.byte_size(avatar_bytes)))
 }


### PR DESCRIPTION
## Summary

Issue #21 reports that the README Quick start shows how to read a file
part's `filename` but never shows how to read the actual byte payload —
new users have to grep `multipartkit/part` and guess at names like
`part.bytes`, `part.content`, or `part.data` (all wrong) before finding
`part.body`. This PR extends the Quick start with a one-line use of
`part.body` plus its byte size, closing the discoverability gap.

## Changes

- `examples/quick_start/src/multipartkit_quick_start.gleam`: add
  `let avatar_bytes = part.body(avatar)` and print
  `avatar size=<n>` using `gleam/bit_array` and `gleam/int`.
- `README.md`: mirror the same change in the first ` ```gleam ` block so
  `scripts/check_readme_snippet.sh` keeps passing (the example file is
  the source of truth and CI diffs them byte-for-byte).
- `CHANGELOG.md`: note the doc change under `[Unreleased]`.

## Design Decisions

- The example file is the canonical source per `check_readme_snippet.sh`,
  so both files are updated in lockstep instead of just patching the
  README.
- Used `bit_array.byte_size` to print a human-meaningful size rather
  than dumping the raw `BitArray`, since the prior lines also print
  human-readable values.
- Kept the example minimal — one extra `let` and one extra
  `io.println` — to avoid making the Quick start denser than it needs
  to be for the discoverability fix.

Closes #21