### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-05
+
 ### Documentation
 
 - **readme**: extend the Quick start snippet with `part.body(avatar)` and

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.5.0"
+version = "0.6.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Documentation

- **readme**: extend the Quick start snippet with `part.body(avatar)` and
  print the byte size of the parsed file part. New users no longer have
  to grep `multipartkit/part` to find the BitArray accessor. The
  `examples/quick_start` source is updated in lockstep so the
  README/example byte-equality check still passes. (#21)
