### PR TITLE
fix(scan): accept RFC 2046 transport-padding around boundary delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- `multipartkit.parse/2` (and the streaming parser, which shares the
+  same delimiter scanner) now accepts RFC 2046 §5.1.1
+  `transport-padding` — `*LWSP-char` (spaces or tabs) between the
+  boundary token and the trailing CRLF/LF (or `--` for the closing
+  delimiter). Previously the scanner only matched `--<boundary>\r\n`
+  exactly, so a body whose opening delimiter was `--BND  \r\n`
+  parsed as `Ok([])` (empty multipart) and silently swallowed every
+  part. Cross-vendor wires routinely arrive with non-zero padding
+  (some HTTP intermediaries inject it for line-length normalisation),
+  so the scanner now follows the RFC. The same change covers the
+  inter-part delimiter and the close-delimiter
+  (`--<boundary>--<padding>\r\n`). (#24)
+
 ## [0.6.0] - 2026-05-05
 
 ### Documentation

--- a/src/multipartkit/internal/scan.gleam
+++ b/src/multipartkit/internal/scan.gleam
@@ -106,38 +106,61 @@ type AfterClass {
 fn classify_after(buf: BitArray, at: Int, total: Int) -> AfterClass {
   case at >= total {
     True -> ClassIncomplete
-    False ->
-      case bit_array.slice(buf, at, 2) {
+    False -> {
+      // RFC 2046 §5.1.1 transport-padding := *LWSP-char between the
+      // boundary token and the line ending (or `--` for the closing
+      // delimiter). Spaces and tabs only.
+      let after_padding = skip_lwsp(buf, at, total)
+      case bit_array.slice(buf, after_padding, 2) {
         Ok(<<"--":utf8>>) ->
-          ClassClosing(consume_closing_tail(buf, at + 2, total))
-        Ok(<<"\r\n":utf8>>) -> ClassDelimiter(at + 2)
-        Ok(<<10, _>>) -> ClassDelimiter(at + 1)
+          ClassClosing(consume_closing_tail(buf, after_padding + 2, total))
+        Ok(<<"\r\n":utf8>>) -> ClassDelimiter(after_padding + 2)
+        Ok(<<10, _>>) -> ClassDelimiter(after_padding + 1)
         _ ->
-          case bit_array.slice(buf, at, 1) {
-            Ok(<<10>>) -> ClassDelimiter(at + 1)
+          case bit_array.slice(buf, after_padding, 1) {
+            Ok(<<10>>) -> ClassDelimiter(after_padding + 1)
             Ok(_) -> {
-              case at + 2 > total {
+              case after_padding + 2 > total {
                 True -> ClassIncomplete
                 False -> ClassInvalid
               }
             }
-            Error(Nil) -> ClassIncomplete
+            Error(Nil) -> {
+              case after_padding >= total {
+                True -> ClassIncomplete
+                False -> ClassInvalid
+              }
+            }
+          }
+      }
+    }
+  }
+}
+
+fn consume_closing_tail(buf: BitArray, at: Int, total: Int) -> Int {
+  let after_padding = skip_lwsp(buf, at, total)
+  case after_padding >= total {
+    True -> after_padding
+    False ->
+      case bit_array.slice(buf, after_padding, 2) {
+        Ok(<<"\r\n":utf8>>) -> after_padding + 2
+        _ ->
+          case bit_array.slice(buf, after_padding, 1) {
+            Ok(<<10>>) -> after_padding + 1
+            _ -> after_padding
           }
       }
   }
 }
 
-fn consume_closing_tail(buf: BitArray, at: Int, total: Int) -> Int {
+fn skip_lwsp(buf: BitArray, at: Int, total: Int) -> Int {
   case at >= total {
     True -> at
     False ->
-      case bit_array.slice(buf, at, 2) {
-        Ok(<<"\r\n":utf8>>) -> at + 2
-        _ ->
-          case bit_array.slice(buf, at, 1) {
-            Ok(<<10>>) -> at + 1
-            _ -> at
-          }
+      case bit_array.slice(buf, at, 1) {
+        Ok(<<32>>) -> skip_lwsp(buf, at + 1, total)
+        Ok(<<9>>) -> skip_lwsp(buf, at + 1, total)
+        _ -> at
       }
   }
 }

--- a/test/multipartkit/parser_transport_padding_test.gleam
+++ b/test/multipartkit/parser_transport_padding_test.gleam
@@ -1,0 +1,64 @@
+import gleam/list
+import gleam/option.{Some}
+import gleeunit/should
+import multipartkit/parser
+import multipartkit/part
+
+const ct = "multipart/form-data; boundary=BND"
+
+pub fn parse_opening_delimiter_with_space_padding_test() {
+  let body = <<
+    "--BND  \r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nhello\r\n--BND--\r\n":utf8,
+  >>
+  let assert Ok(parts) = parser.parse(body, ct)
+  list.length(parts) |> should.equal(1)
+  let assert [single] = parts
+  part.name(single) |> should.equal(Some("a"))
+  part.body(single) |> should.equal(<<"hello":utf8>>)
+}
+
+pub fn parse_inter_part_delimiter_with_tab_padding_test() {
+  let body = <<
+    "--BND\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nhello\r\n--BND\t\r\nContent-Disposition: form-data; name=\"b\"\r\n\r\nworld\r\n--BND--\r\n":utf8,
+  >>
+  let assert Ok(parts) = parser.parse(body, ct)
+  list.length(parts) |> should.equal(2)
+  let assert [first, second] = parts
+  part.name(first) |> should.equal(Some("a"))
+  part.name(second) |> should.equal(Some("b"))
+}
+
+pub fn parse_closing_delimiter_with_padding_test() {
+  let body = <<
+    "--BND\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nhello\r\n--BND--  \r\n":utf8,
+  >>
+  let assert Ok([field_part]) = parser.parse(body, ct)
+  part.body(field_part) |> should.equal(<<"hello":utf8>>)
+}
+
+pub fn parse_lf_terminated_with_padding_test() {
+  let body = <<
+    "--BND \nContent-Disposition: form-data; name=\"a\"\n\nhi\n--BND--\n":utf8,
+  >>
+  let assert Ok([field_part]) = parser.parse(body, ct)
+  part.body(field_part) |> should.equal(<<"hi":utf8>>)
+}
+
+pub fn parse_mixed_space_and_tab_padding_test() {
+  // Multiple LWSP-chars (space, tab, space) in one delimiter.
+  let body = <<
+    "--BND \t \r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nv\r\n--BND--\r\n":utf8,
+  >>
+  let assert Ok([field_part]) = parser.parse(body, ct)
+  part.name(field_part) |> should.equal(Some("a"))
+  part.body(field_part) |> should.equal(<<"v":utf8>>)
+}
+
+pub fn parse_zero_padding_still_works_test() {
+  // Sanity: previously-correct, padding-free bodies must still parse.
+  let body = <<
+    "--BND\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nhello\r\n--BND--\r\n":utf8,
+  >>
+  let assert Ok([field_part]) = parser.parse(body, ct)
+  part.body(field_part) |> should.equal(<<"hello":utf8>>)
+}


### PR DESCRIPTION
## Summary

`multipartkit.parse/2` (and the streaming parser, which shares the same delimiter scanner) silently swallowed every part of an otherwise-valid body when the boundary delimiter carried `transport-padding` — `*LWSP-char` (spaces or tabs) between the boundary token and the trailing CRLF/LF or `--`. RFC 2046 §5.1.1 explicitly permits this padding, and some HTTP intermediaries inject it for line-length normalisation.

## Changes

- `src/multipartkit/internal/scan.gleam`: insert a `skip_lwsp/3` step into `classify_after/3` and `consume_closing_tail/3` so spaces/tabs between the boundary token and the line ending (or the closing `--`) are consumed before the line-end shape is matched. Covers the opening dash-boundary, every inter-part delimiter, and the close-delimiter.
- `test/multipartkit/parser_transport_padding_test.gleam` (new): six regressions —
  - opening delimiter with two spaces (Issue #24's exact reproducer),
  - inter-part delimiter with a tab,
  - closing delimiter with two spaces,
  - LF-terminated delimiter with one space,
  - mixed space/tab/space padding,
  - sanity check that zero-padding bodies still parse.
- `CHANGELOG.md`: \`Unreleased > Fixed\` entry referencing #24.

## Design Decisions

- **Did not introduce a strict mode that rejects non-LWSP padding.** RFC 2046 only allows `LWSP-char` (SP or HTAB), and `skip_lwsp` only consumes those two byte values; anything else falls through to the existing `ClassInvalid` path, which already retries the search forward. That gives the conservative behaviour for free without an extra error variant.
- **Single helper covers all three delimiter kinds.** The scanner's three call-sites all pass through `classify_after/3` (or `consume_closing_tail/3` for the trailing CRLF after `--<boundary>--`). Putting `skip_lwsp` at those two seams handles opening, inter-part, and closing delimiters in one change rather than scattering padding-skip logic.
- **Removed stale `examples/*/manifest.toml` lock files** out of band so `just all` (which builds and runs every example) succeeds. The lock files pinned `multipartkit` at v0.5.0 and were not in version control (`git ls-files` confirms they are gitignored); they were left over from a previous local build and are regenerated on the next `gleam deps download`.

Closes #24