### PR TITLE
fix(part): reject CRLF and NUL in headers to close CRLF injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+- **multipart CRLF / NUL injection in `Part.new/5`** —
+  `multipartkit/part.new/5` now validates header names and values
+  before constructing a `Part` and returns
+  `Result(Part, MultipartError)` instead of `Part`. Header values
+  containing `\r`, `\n`, or NUL are rejected with
+  `Error(InvalidHeaderValue(name, value))`; header names containing
+  any of those bytes or a `:` are rejected with
+  `Error(InvalidHeaderName(name))`. Previously, an attacker who
+  controlled a header value could smuggle additional header lines
+  into the encoded wire image — the multipart variant of CRLF
+  response splitting (RFC 9110 §5.5 disallows these bytes in
+  `field-value`). Two new variants in `MultipartError`,
+  `InvalidHeaderName` and `InvalidHeaderValue`, surface the rejection.
+  Internal callers (`form.add_field`, `form.add_file*`,
+  `parser.parse`) already sanitise or pre-validate their input and
+  use a new `@internal` `part.unchecked_new` helper that skips the
+  check; no behaviour change for callers of the `form` builder. (#28)
+
+### Breaking change (security fix)
+- `Part.new/5` signature is now
+  `Result(Part, MultipartError)` instead of `Part`. Existing
+  call sites must `use part <- result.try(part.new(...))` (or
+  `let assert Ok(part) = part.new(...)` when input is statically
+  safe). The bug closed by this change is severe enough to justify
+  a major bump on its own.
+
 ## [0.7.0] - 2026-05-06
 
 ### Fixed

--- a/src/multipartkit/error.gleam
+++ b/src/multipartkit/error.gleam
@@ -39,4 +39,16 @@ pub type MultipartError {
   /// Validation rejected a part because its `Content-Type` is outside an
   /// application-supplied allow-list.
   DisallowedContentType(String)
+  /// `Part.new/5` was given a header whose value contains a `CR` (`\r`),
+  /// `LF` (`\n`), or `NUL` byte. Allowing these unchecked would let an
+  /// attacker who controls the value smuggle additional header lines
+  /// into the encoded wire image — the multipart variant of CRLF
+  /// response splitting. The carried name and value are the offending
+  /// pair so callers can render diagnostics without re-parsing.
+  InvalidHeaderValue(name: String, value: String)
+  /// `Part.new/5` was given a header whose name contains a `CR`, `LF`,
+  /// `NUL`, or `:`. Header names that include any of these would either
+  /// inject a header break or split into a different `name: value` pair
+  /// at parse time. Carries the offending name.
+  InvalidHeaderName(name: String)
 }

--- a/src/multipartkit/form.gleam
+++ b/src/multipartkit/form.gleam
@@ -37,7 +37,7 @@ pub fn add_field(form: Form, name: String, value: String) -> Form {
     "form-data; name=" <> quote(safe_name),
   )
   let new_part =
-    part.new(
+    part.unchecked_new(
       headers: [disposition],
       name: Some(safe_name),
       filename: None,
@@ -142,7 +142,7 @@ fn build_file_part(
       <> filename_disposition_params(safe_filename),
   )
   let content_type_header = #("Content-Type", safe_content_type)
-  part.new(
+  part.unchecked_new(
     headers: [disposition_header, content_type_header],
     name: Some(safe_name),
     filename: Some(safe_filename),

--- a/src/multipartkit/parser.gleam
+++ b/src/multipartkit/parser.gleam
@@ -91,7 +91,7 @@ fn parse_loop(
                                   body_size,
                                 )
                               let new_part =
-                                part.new(
+                                part.unchecked_new(
                                   headers: header_list,
                                   name: meta.name,
                                   filename: meta.filename,

--- a/src/multipartkit/part.gleam
+++ b/src/multipartkit/part.gleam
@@ -1,5 +1,11 @@
+import gleam/bool
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
+import multipartkit/error.{
+  type MultipartError, InvalidHeaderName, InvalidHeaderValue,
+}
 import multipartkit/internal/text
 
 /// A parsed multipart part.
@@ -39,11 +45,45 @@ pub opaque type Part {
   )
 }
 
-/// Construct a `Part`. The `name`, `filename`, and `content_type` fields
-/// are not re-derived from the `headers` list — pass the values you
-/// expect callers to see, or use `parser.parse` for automatic
-/// derivation.
+/// Construct a `Part`.
+///
+/// The `name`, `filename`, and `content_type` fields are not re-derived
+/// from the `headers` list — pass the values you expect callers to see,
+/// or use `parser.parse` for automatic derivation.
+///
+/// Header names and values are validated to prevent CRLF / NUL injection
+/// into the encoded wire image. A header value that contains `\r`, `\n`,
+/// or NUL would otherwise let an attacker who controls the value smuggle
+/// additional header lines into the encoded part — the multipart variant
+/// of CRLF response splitting (RFC 9110 §5.5 disallows these bytes in
+/// `field-value`). Header names additionally cannot contain `:` (would
+/// split the header at parse time). The constructor rejects these inputs
+/// with `Error(InvalidHeaderName(_))` / `Error(InvalidHeaderValue(_, _))`
+/// rather than silently emitting an off-spec wire image.
 pub fn new(
+  headers headers: List(#(String, String)),
+  name name: Option(String),
+  filename filename: Option(String),
+  content_type content_type: Option(String),
+  body body: BitArray,
+) -> Result(Part, MultipartError) {
+  use _ <- result.try(validate_headers(headers))
+  Ok(Part(
+    headers: headers,
+    name: name,
+    filename: filename,
+    content_type: content_type,
+    body: body,
+  ))
+}
+
+/// Internal escape hatch — skips header-injection validation. Used by
+/// `multipartkit/form` and the parser, both of which sanitise or
+/// already-validated their inputs before constructing the `Part`. NOT
+/// part of the public surface; the `@internal` attribute keeps it out
+/// of the rendered docs and signals the contract to other tooling.
+@internal
+pub fn unchecked_new(
   headers headers: List(#(String, String)),
   name name: Option(String),
   filename filename: Option(String),
@@ -57,6 +97,42 @@ pub fn new(
     content_type: content_type,
     body: body,
   )
+}
+
+fn validate_headers(
+  headers: List(#(String, String)),
+) -> Result(Nil, MultipartError) {
+  case headers {
+    [] -> Ok(Nil)
+    [#(name, value), ..rest] -> {
+      use <- bool.guard(
+        when: !valid_header_name(name),
+        return: Error(InvalidHeaderName(name)),
+      )
+      use <- bool.guard(
+        when: !valid_header_value(value),
+        return: Error(InvalidHeaderValue(name, value)),
+      )
+      validate_headers(rest)
+    }
+  }
+}
+
+fn valid_header_name(name: String) -> Bool {
+  !{
+    string.contains(name, "\r")
+    || string.contains(name, "\n")
+    || string.contains(name, "\u{0000}")
+    || string.contains(name, ":")
+  }
+}
+
+fn valid_header_value(value: String) -> Bool {
+  !{
+    string.contains(value, "\r")
+    || string.contains(value, "\n")
+    || string.contains(value, "\u{0000}")
+  }
 }
 
 /// All headers as `(name, value)` pairs in input order.

--- a/test/multipartkit/encoder_test.gleam
+++ b/test/multipartkit/encoder_test.gleam
@@ -15,7 +15,7 @@ pub fn encode_zero_parts_test() {
 }
 
 pub fn encode_single_field_test() {
-  let part_value =
+  let assert Ok(part_value) =
     part.new(
       headers: [#("Content-Disposition", "form-data; name=\"a\"")],
       name: Some("a"),
@@ -32,7 +32,7 @@ pub fn encode_single_field_test() {
 pub fn encode_emits_headers_verbatim_test() {
   // The encoder should not synthesize headers; it should emit exactly what
   // we pass.
-  let part_value =
+  let assert Ok(part_value) =
     part.new(
       headers: [#("X-First", "1"), #("X-Second", "two")],
       name: None,
@@ -85,7 +85,7 @@ pub fn encode_form_generates_fresh_boundary_test() {
 }
 
 pub fn encode_stream_round_trips_via_buffer_test() {
-  let part0 =
+  let assert Ok(part0) =
     part.new(
       headers: [#("Content-Disposition", "form-data; name=\"a\"")],
       name: Some("a"),

--- a/test/multipartkit/form_test.gleam
+++ b/test/multipartkit/form_test.gleam
@@ -80,7 +80,7 @@ pub fn add_file_auto_with_bytes_inferer_fallback_test() {
 }
 
 pub fn unsafe_add_part_inserts_verbatim_test() {
-  let manual =
+  let assert Ok(manual) =
     part.new(
       headers: [#("X-Custom", "v")],
       name: None,

--- a/test/multipartkit/golden_fixtures_test.gleam
+++ b/test/multipartkit/golden_fixtures_test.gleam
@@ -55,7 +55,7 @@ const fixture_form_data_body: BitArray = <<
 >>
 
 pub fn encoder_emits_canonical_form_data_body_test() {
-  let title =
+  let assert Ok(title) =
     part.new(
       headers: [#("Content-Disposition", "form-data; name=\"title\"")],
       name: Some("title"),
@@ -63,7 +63,7 @@ pub fn encoder_emits_canonical_form_data_body_test() {
       content_type: None,
       body: <<"hi":utf8>>,
     )
-  let avatar =
+  let assert Ok(avatar) =
     part.new(
       headers: [
         #(

--- a/test/multipartkit/part_test.gleam
+++ b/test/multipartkit/part_test.gleam
@@ -1,20 +1,23 @@
 import gleam/option.{None, Some}
 import gleeunit/should
+import multipartkit/error.{InvalidHeaderName, InvalidHeaderValue}
 import multipartkit/part.{type Part}
 
 fn sample() -> Part {
-  part.new(
-    headers: [
-      #("Content-Disposition", "form-data; name=\"a\""),
-      #("X-Trace", "first"),
-      #("x-trace", "second"),
-      #("X-TRACE", "third"),
-    ],
-    name: Some("a"),
-    filename: None,
-    content_type: None,
-    body: <<>>,
-  )
+  let assert Ok(p) =
+    part.new(
+      headers: [
+        #("Content-Disposition", "form-data; name=\"a\""),
+        #("X-Trace", "first"),
+        #("x-trace", "second"),
+        #("X-TRACE", "third"),
+      ],
+      name: Some("a"),
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  p
 }
 
 pub fn header_finds_first_match_case_insensitively_test() {
@@ -30,6 +33,86 @@ pub fn headers_returns_all_in_storage_order_test() {
   |> should.equal(["first", "second", "third"])
 }
 
+pub fn new_rejects_lf_in_header_value_test() {
+  // #28: a header value containing `\n` would split into two header
+  // lines on the wire and let an attacker who controls the value
+  // smuggle additional headers.
+  part.new(
+    headers: [#("X-Foo", "good\nX-Injected: malicious")],
+    name: None,
+    filename: None,
+    content_type: None,
+    body: <<>>,
+  )
+  |> should.equal(
+    Error(InvalidHeaderValue("X-Foo", "good\nX-Injected: malicious")),
+  )
+}
+
+pub fn new_rejects_crlf_in_header_value_test() {
+  // The exact case from the issue reproducer.
+  part.new(
+    headers: [#("X-Foo", "good\r\nX-Injected: malicious")],
+    name: None,
+    filename: None,
+    content_type: None,
+    body: <<>>,
+  )
+  |> should.equal(
+    Error(InvalidHeaderValue("X-Foo", "good\r\nX-Injected: malicious")),
+  )
+}
+
+pub fn new_rejects_nul_in_header_value_test() {
+  // NUL byte in a header value would either be silently truncated by
+  // some C-string consumers or pass through as a literal — both bad.
+  part.new(
+    headers: [#("X-Foo", "good\u{0000}injected")],
+    name: None,
+    filename: None,
+    content_type: None,
+    body: <<>>,
+  )
+  |> should.equal(Error(InvalidHeaderValue("X-Foo", "good\u{0000}injected")))
+}
+
+pub fn new_rejects_lf_in_header_name_test() {
+  // Header name containing `\n` would also inject a header break.
+  part.new(
+    headers: [#("X-Foo\nX-Injected", "value")],
+    name: None,
+    filename: None,
+    content_type: None,
+    body: <<>>,
+  )
+  |> should.equal(Error(InvalidHeaderName("X-Foo\nX-Injected")))
+}
+
+pub fn new_rejects_colon_in_header_name_test() {
+  // `:` in a header name would split into a different `name: value`
+  // pair on parse — the parser uses the first `:` as the separator.
+  part.new(
+    headers: [#("X-Foo: smuggled", "value")],
+    name: None,
+    filename: None,
+    content_type: None,
+    body: <<>>,
+  )
+  |> should.equal(Error(InvalidHeaderName("X-Foo: smuggled")))
+}
+
+pub fn new_accepts_valid_headers_test() {
+  // Sanity check: ordinary header values still construct cleanly.
+  part.new(
+    headers: [#("Content-Disposition", "form-data; name=\"a\"")],
+    name: Some("a"),
+    filename: None,
+    content_type: None,
+    body: <<"hi":utf8>>,
+  )
+  |> should.be_ok
+}
+
 pub fn header_lookup_uses_ascii_only_case_folding_test() {
   // Locale-sensitive lowercase folds Turkish I-with-dot to a lowercase i, but
   // ASCII case-insensitive comparison should not. Make sure non-ASCII names
@@ -37,7 +120,7 @@ pub fn header_lookup_uses_ascii_only_case_folding_test() {
   let dotless = "X-Custom-İ"
   // Add a part with a header named like that and look up "x-custom-i"; they
   // must NOT match.
-  let p =
+  let assert Ok(p) =
     part.new(
       headers: [#(dotless, "value")],
       name: None,

--- a/test/multipartkit/query_test.gleam
+++ b/test/multipartkit/query_test.gleam
@@ -5,33 +5,39 @@ import multipartkit/part.{type Part}
 import multipartkit/query
 
 fn text_part(name: String, body: BitArray) -> Part {
-  part.new(
-    headers: [],
-    name: Some(name),
-    filename: None,
-    content_type: None,
-    body: body,
-  )
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: Some(name),
+      filename: None,
+      content_type: None,
+      body: body,
+    )
+  p
 }
 
 fn file_part(name: String, filename: String, body: BitArray) -> Part {
-  part.new(
-    headers: [],
-    name: Some(name),
-    filename: Some(filename),
-    content_type: None,
-    body: body,
-  )
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: Some(name),
+      filename: Some(filename),
+      content_type: None,
+      body: body,
+    )
+  p
 }
 
 fn anonymous_part(body: BitArray) -> Part {
-  part.new(
-    headers: [],
-    name: None,
-    filename: None,
-    content_type: None,
-    body: body,
-  )
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: body,
+    )
+  p
 }
 
 pub fn field_returns_first_match_test() {

--- a/test/multipartkit/roundtrip_test.gleam
+++ b/test/multipartkit/roundtrip_test.gleam
@@ -7,14 +7,15 @@ import multipartkit/part
 const ct = "multipart/form-data; boundary=ROUND"
 
 pub fn parse_then_encode_then_parse_test() {
-  let parts = [
+  let assert Ok(p1) =
     part.new(
       headers: [#("Content-Disposition", "form-data; name=\"a\"")],
       name: Some("a"),
       filename: None,
       content_type: None,
       body: <<"first":utf8>>,
-    ),
+    )
+  let assert Ok(p2) =
     part.new(
       headers: [
         #("Content-Disposition", "form-data; name=\"b\"; filename=\"f.bin\""),
@@ -24,23 +25,23 @@ pub fn parse_then_encode_then_parse_test() {
       filename: Some("f.bin"),
       content_type: Some("application/octet-stream"),
       body: <<0, 0xFE, 1, 2>>,
-    ),
-  ]
+    )
+  let parts = [p1, p2]
   let bytes = encoder.encode("ROUND", parts)
   let assert Ok(reparsed) = parser.parse(bytes, ct)
   reparsed |> should.equal(parts)
 }
 
 pub fn encode_canonical_then_parse_byte_identical_test() {
-  let parts = [
+  let assert Ok(p) =
     part.new(
       headers: [#("Content-Disposition", "form-data; name=\"a\"")],
       name: Some("a"),
       filename: None,
       content_type: None,
       body: <<"x":utf8>>,
-    ),
-  ]
+    )
+  let parts = [p]
   let first = encoder.encode("ROUND", parts)
   let assert Ok(reparsed) = parser.parse(first, ct)
   let second = encoder.encode("ROUND", reparsed)
@@ -48,15 +49,15 @@ pub fn encode_canonical_then_parse_byte_identical_test() {
 }
 
 pub fn empty_body_round_trip_test() {
-  let parts = [
+  let assert Ok(p) =
     part.new(
       headers: [#("Content-Disposition", "form-data; name=\"empty\"")],
       name: Some("empty"),
       filename: None,
       content_type: None,
       body: <<>>,
-    ),
-  ]
+    )
+  let parts = [p]
   let bytes = encoder.encode("ROUND", parts)
   let assert Ok(reparsed) = parser.parse(bytes, ct)
   reparsed |> should.equal(parts)

--- a/test/multipartkit/validate_test.gleam
+++ b/test/multipartkit/validate_test.gleam
@@ -5,13 +5,15 @@ import multipartkit/part.{type Part}
 import multipartkit/validate
 
 fn build_part(name: String, ct: Option(String), body: BitArray) -> Part {
-  part.new(
-    headers: [],
-    name: Some(name),
-    filename: None,
-    content_type: ct,
-    body: body,
-  )
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: Some(name),
+      filename: None,
+      content_type: ct,
+      body: body,
+    )
+  p
 }
 
 pub fn has_field_true_test() {


### PR DESCRIPTION
## Summary

`multipartkit/part.new/5` accepted any string for header names and
values without validation. A header value containing `\r\n` therefore
got interleaved with the rest of the headers in the encoded wire
image, and the parser on the receiving side accepted the smuggled
line as a real header. Issue #28 reproduced this end-to-end against
the same library: a single `X-Foo` header from the caller produced
two parsed headers, including one the caller never set. This is a
multipart-context CRLF injection — the same shape as classic CRLF
response splitting, scoped to multipart consumers.

## Changes

- `src/multipartkit/error.gleam`: two new variants —
  `InvalidHeaderName(name)` and `InvalidHeaderValue(name, value)` —
  carry the offending pair so callers can render diagnostics
  without re-parsing.
- `src/multipartkit/part.gleam`:
  - `Part.new/5` signature changes from `Part` to
    `Result(Part, MultipartError)`. The constructor walks `headers`
    and rejects any name containing `\r`, `\n`, NUL, or `:`, and
    any value containing `\r`, `\n`, or NUL. The docstring spells
    out the rule and points at RFC 9110 §5.5.
  - New `@internal` `unchecked_new/5` returns `Part` directly,
    bypassing validation. Used only by sibling internal modules
    that already sanitise (`form`) or already validated
    (`parser`) their input. The `@internal` attribute keeps it out
    of HexDocs and signals the contract.
- `src/multipartkit/form.gleam`, `src/multipartkit/parser.gleam`:
  use the internal `unchecked_new` helper so they don't
  unwrap a `Result` they statically can't fail.
- `test/multipartkit/part_test.gleam`: five new tests cover LF,
  CRLF, and NUL in values; LF in names; and `:` in names. Plus a
  positive control that ordinary valid headers still construct.
- All other test files updated to the new `let assert Ok(part) = ...`
  call shape.
- `CHANGELOG.md`: `[Unreleased] / Security` entry documents the
  bug, the fix, and the breaking-change migration shape.

## Design Decisions

- **Reject rather than sanitise.** Issue #28 listed three
  options; (1) "reject at construction" matches how the rest of
  the API treats malformed input — `parser.parse` and
  `parse_with_limits` already return `Result`. Sanitise-on-encode
  would let invalid `Part` values propagate through the system
  and be observable by equality / property tests, which is
  worse than failing loudly at construction.
- **`@internal` escape hatch, not panic-on-`assert Ok`.** Form
  and parser callers know their input is already safe; making
  them unwrap a `Result` would be either a wasteful round-trip
  through `result.try` or a `let assert Ok(...)` that the project's
  glinter rules already disallow in `src/`. An `@internal`
  helper documents the contract and keeps the rendered docs
  clean. (Gleam `@internal` is the language-level signal for
  "library-private but callable across module boundaries"; it
  matches the spirit of the existing `internal_modules`
  declaration in `gleam.toml`.)
- **Reject `:` in header *names* in addition to CR/LF/NUL.** The
  parser uses the first `:` as the name/value separator, so a
  name containing `:` would split into a different `name: value`
  pair on parse — a different shape of injection from CRLF but
  the same blast radius. Closing both at construction time is
  cheaper than closing only the obvious one.

## Limitations

- This is a **breaking change** to `Part.new/5`'s signature.
  Issue #28 explicitly notes that the bug is severe enough to
  justify the major bump; the CHANGELOG entry calls out the
  migration (`use part <- result.try(part.new(...))` for the
  fallible path, `let assert Ok(part) = part.new(...)` for the
  statically-safe path).

Closes #28
