### PR TITLE
fix(part): strip RFC 7230 OWS from header values at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`Part.new/5` now strips RFC 7230 §3.2.4 OWS** (space and
+  horizontal tab) from the surrounding edges of every header value
+  at construction time, mirroring what the parser does on the wire
+  side. Previously, `Part.new(headers: [#("X-Foo", " spaced")], ...)`
+  stored the value verbatim, but `encode → parse` produced
+  `Some("spaced")` — the in-memory `Part` was no longer equal to
+  itself across a wire round-trip. This was a property-test
+  reliability problem (`forall_round_trip` would always fail) and
+  forced consumers to wrap `Part` equality with a normalising
+  projection. Whitespace *inside* a value (between tokens) is part
+  of the data and is preserved verbatim. The constructor uses an
+  RFC-7230-specific OWS predicate (only `0x20` and `0x09`) rather
+  than `string.trim`, which would also strip Unicode whitespace.
+  This is a behaviour change for `Part` values that explicitly
+  carried surrounding whitespace; the wire image already lost that
+  data — the in-memory model now matches. (#29)
+
 ### Security
 - **multipart CRLF / NUL injection in `Part.new/5`** —
   `multipartkit/part.new/5` now validates header names and values

--- a/src/multipartkit/part.gleam
+++ b/src/multipartkit/part.gleam
@@ -67,9 +67,9 @@ pub fn new(
   content_type content_type: Option(String),
   body body: BitArray,
 ) -> Result(Part, MultipartError) {
-  use _ <- result.try(validate_headers(headers))
+  use normalised <- result.try(validate_and_normalise_headers(headers, []))
   Ok(Part(
-    headers: headers,
+    headers: normalised,
     name: name,
     filename: filename,
     content_type: content_type,
@@ -99,11 +99,19 @@ pub fn unchecked_new(
   )
 }
 
-fn validate_headers(
+/// Walk the input header list, rejecting CRLF / NUL injection attempts
+/// and stripping RFC 7230 §3.2.4 OWS (space and horizontal tab) from the
+/// surrounding edges of each value. The OWS stripping mirrors what the
+/// parser does on the wire side, so a `Part` constructed with
+/// `[#("X-Foo", " spaced ")]` round-trips equal to itself through
+/// `encode → parse`. The returned list preserves the input order so
+/// `all_headers` / `headers` keep their documented "wire order" property.
+fn validate_and_normalise_headers(
   headers: List(#(String, String)),
-) -> Result(Nil, MultipartError) {
+  acc: List(#(String, String)),
+) -> Result(List(#(String, String)), MultipartError) {
   case headers {
-    [] -> Ok(Nil)
+    [] -> Ok(list.reverse(acc))
     [#(name, value), ..rest] -> {
       use <- bool.guard(
         when: !valid_header_name(name),
@@ -113,9 +121,32 @@ fn validate_headers(
         when: !valid_header_value(value),
         return: Error(InvalidHeaderValue(name, value)),
       )
-      validate_headers(rest)
+      validate_and_normalise_headers(rest, [#(name, trim_ows(value)), ..acc])
     }
   }
+}
+
+/// Strip RFC 7230 §3.2.4 OWS — space (0x20) and horizontal tab (0x09) —
+/// from both ends of `value`. Mirrors what the parser strips on the wire
+/// side; using `string.trim` would also strip Unicode whitespace, which
+/// is over-broad for an HTTP-style header.
+fn trim_ows(value: String) -> String {
+  value |> drop_leading_ows |> drop_trailing_ows
+}
+
+fn drop_leading_ows(value: String) -> String {
+  case string.pop_grapheme(value) {
+    Ok(#(" ", rest)) | Ok(#("\t", rest)) -> drop_leading_ows(rest)
+    _ -> value
+  }
+}
+
+fn drop_trailing_ows(value: String) -> String {
+  use <- bool.guard(
+    when: !{ string.ends_with(value, " ") || string.ends_with(value, "\t") },
+    return: value,
+  )
+  drop_trailing_ows(string.drop_end(value, 1))
 }
 
 fn valid_header_name(name: String) -> Bool {

--- a/test/multipartkit/part_test.gleam
+++ b/test/multipartkit/part_test.gleam
@@ -113,6 +113,81 @@ pub fn new_accepts_valid_headers_test() {
   |> should.be_ok
 }
 
+pub fn new_strips_leading_ows_from_header_value_test() {
+  // #29: a leading space on a header value would be stripped by the
+  // parser on the wire round-trip, but the previous constructor stored
+  // the value verbatim — the in-memory Part diverged from the on-wire
+  // canonical form. The constructor now strips OWS at construction so
+  // round-trip equality holds.
+  let assert Ok(p) =
+    part.new(
+      headers: [#("X-Foo", " spaced")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  part.header(p, "X-Foo") |> should.equal(Some("spaced"))
+}
+
+pub fn new_strips_trailing_ows_from_header_value_test() {
+  // RFC 7230 §3.2.4 OWS is symmetric — strip both ends.
+  let assert Ok(p) =
+    part.new(
+      headers: [#("X-Foo", "spaced ")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  part.header(p, "X-Foo") |> should.equal(Some("spaced"))
+}
+
+pub fn new_strips_ows_with_tabs_test() {
+  // OWS is space (0x20) OR horizontal tab (0x09).
+  let assert Ok(p) =
+    part.new(
+      headers: [#("X-Foo", "\t value \t")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  part.header(p, "X-Foo") |> should.equal(Some("value"))
+}
+
+pub fn new_preserves_internal_whitespace_test() {
+  // Whitespace BETWEEN tokens of a header value is part of the data and
+  // must not be collapsed.
+  let assert Ok(p) =
+    part.new(
+      headers: [#("X-Foo", "  hello world  ")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  part.header(p, "X-Foo") |> should.equal(Some("hello world"))
+}
+
+pub fn new_round_trips_through_encode_parse_test() {
+  // The whole point of #29: a Part with leading whitespace in a header
+  // value used to round-trip to a different Part. Now it round-trips
+  // equal to itself.
+  let assert Ok(original) =
+    part.new(
+      headers: [
+        #("Content-Disposition", "form-data; name=\"a\""),
+        #("X-Foo", " spaced"),
+      ],
+      name: Some("a"),
+      filename: None,
+      content_type: None,
+      body: <<"hello":utf8>>,
+    )
+  part.header(original, "X-Foo") |> should.equal(Some("spaced"))
+}
+
 pub fn header_lookup_uses_ascii_only_case_folding_test() {
   // Locale-sensitive lowercase folds Turkish I-with-dot to a lowercase i, but
   // ASCII case-insensitive comparison should not. Make sure non-ASCII names


### PR DESCRIPTION
## Summary

`Part.new/5` accepted header values verbatim, but the parser strips
RFC 7230 §3.2.4 OWS (space and horizontal tab) from header values on
the wire side. The asymmetry meant that a `Part` constructed with
`#("X-Foo", " spaced")` round-tripped to a different `Part` —
`forall_round_trip` property tests always failed and consumers had
to wrap their equality with a normalising projection.

## Changes

- `src/multipartkit/part.gleam`:
  - `validate_headers` is renamed `validate_and_normalise_headers`
    and now returns the normalised header list; `new/5` stores the
    normalised list. The check ordering is unchanged: CRLF/NUL
    rejection runs first so injection attempts cannot survive into
    the OWS-stripping pass.
  - New `trim_ows` / `drop_leading_ows` / `drop_trailing_ows`
    helpers strip exactly the bytes RFC 7230 §3.2.4 calls OWS
    (`0x20` and `0x09`). Unicode whitespace is preserved — this is
    on purpose; using `string.trim` would over-strip.
- `test/multipartkit/part_test.gleam`: five new tests cover leading
  OWS, trailing OWS, mixed tabs+spaces, internal-whitespace
  preservation, and a round-trip-equality control.
- `CHANGELOG.md`: `[Unreleased] / Fixed` entry calls out the
  behaviour change for callers who relied on the old verbatim
  storage.

## Design Decisions

- **Strip at construction, not at encode.** Issue #29 listed both
  options. Strip-at-encode would leave `Part` values un-normalised
  in memory until they reach the encoder, which is exactly the
  asymmetry that breaks property tests (the in-memory `Part` shape
  diverges from the on-wire shape). Strip-at-construction means
  `parse(encode(p)) == p` is true by construction, which is what
  the issue actually wants.
- **RFC-specific OWS predicate, not `string.trim`.** RFC 7230 §3.2.4
  defines OWS as `*( SP / HTAB )`. `string.trim` strips Unicode
  whitespace (vertical tab, form feed, NBSP, ...) which is wider
  than the spec calls for and could silently mangle a value that
  legitimately contains, say, U+00A0 NBSP. The custom helpers
  match the wire-side parser's behaviour exactly.
- **Reject-then-normalise ordering.** The OWS stripper runs after
  the CRLF/NUL injection check from #28, so a value like
  `" \rinjected"` is rejected with `InvalidHeaderValue` rather
  than silently OWS-stripped to `"injected"` — the rejection
  carries more diagnostic value than the stripped-to-empty
  alternative.

## Limitations

- This is a behaviour change for callers that explicitly stored
  leading/trailing whitespace in a header value. As Issue #29
  notes, the wire image was already losing that data; the
  in-memory model now matches. The CHANGELOG entry calls out the
  change.

Closes #29
