### PR TITLE
feat(part): add equal_on_wire / list_equal_on_wire for round-trip tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`part.equal_on_wire/2`** and **`part.list_equal_on_wire/2`** —
+  structural equality predicates that compare two `Part` values (or
+  two `Part` lists) by their wire-level content. The comparison
+  preserves header order and uses case-sensitive header-name
+  matching (mirroring RFC 7578 §4.2), and intentionally ignores the
+  convenience cache fields (`name`, `filename`, `content_type`)
+  because those are derived from the headers and may differ between
+  a `Part.new/5`-constructed value and a parsed `Part` even when
+  the wire image is byte-identical. Previously, every consumer that
+  wanted "do these encode to the same bytes?" had to project to
+  `(all_headers, body)` themselves; multipartkit now owns that
+  equality so the right RFC interpretation lives in one place and
+  consumers can keep the projection out of property-test code. (#27)
+
 ### Fixed
 - **`Part.new/5` now strips RFC 7230 §3.2.4 OWS** (space and
   horizontal tab) from the surrounding edges of every header value

--- a/src/multipartkit/part.gleam
+++ b/src/multipartkit/part.gleam
@@ -210,6 +210,42 @@ pub fn headers(part: Part, name: String) -> List(String) {
   find_header(part.headers, name)
 }
 
+/// Structural equality on the wire-level content of two `Part` values.
+///
+/// Compares the headers list (preserving order, with case-sensitive
+/// name matching that mirrors RFC 7578 §4.2) and the body bytes. The
+/// convenience cache fields — `name`, `filename`, `content_type` — are
+/// intentionally ignored because they are derived from the headers
+/// and may differ between a `Part.new/5`-constructed value (where the
+/// caller passes the cache) and a parsed `Part` (where the parser
+/// derives the cache from `Content-Disposition` / `Content-Type`).
+/// Two `Part`s that `equal_on_wire` returns `True` for will encode
+/// to the same bytes via `multipartkit.encode/2` (modulo the
+/// boundary string, which is supplied at encode time).
+///
+/// Use this for property-style round-trip tests where the caller
+/// passes one `Part` shape into the encoder and gets another
+/// (cache-derived) shape back from the parser.
+pub fn equal_on_wire(a: Part, b: Part) -> Bool {
+  a.headers == b.headers && a.body == b.body
+}
+
+/// `equal_on_wire` lifted over a pair of `Part` lists. Returns `True`
+/// when the lists have the same length and every paired element
+/// satisfies `equal_on_wire`.
+pub fn list_equal_on_wire(a: List(Part), b: List(Part)) -> Bool {
+  case a, b {
+    [], [] -> True
+    [], _ -> False
+    _, [] -> False
+    [first_a, ..rest_a], [first_b, ..rest_b] ->
+      case equal_on_wire(first_a, first_b) {
+        True -> list_equal_on_wire(rest_a, rest_b)
+        False -> False
+      }
+  }
+}
+
 fn find_header(headers: List(#(String, String)), name: String) -> List(String) {
   list.filter_map(headers, fn(entry) {
     case text.equals_ci(entry.0, name) {

--- a/test/multipartkit/part_test.gleam
+++ b/test/multipartkit/part_test.gleam
@@ -188,6 +188,117 @@ pub fn new_round_trips_through_encode_parse_test() {
   part.header(original, "X-Foo") |> should.equal(Some("spaced"))
 }
 
+pub fn equal_on_wire_true_when_headers_and_body_match_test() {
+  // #27: two parts with identical headers + body but different cache
+  // fields (`name`, `filename`, `content_type`) compare equal on
+  // the wire.
+  let assert Ok(a) =
+    part.new(
+      headers: [#("Content-Disposition", "form-data; name=\"a\"")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<"hello":utf8>>,
+    )
+  let assert Ok(b) =
+    part.new(
+      headers: [#("Content-Disposition", "form-data; name=\"a\"")],
+      name: Some("a"),
+      filename: None,
+      content_type: None,
+      body: <<"hello":utf8>>,
+    )
+  // Structural `==` differs because `name` is None vs Some("a").
+  // `equal_on_wire` ignores that and returns True.
+  part.equal_on_wire(a, b) |> should.be_true
+}
+
+pub fn equal_on_wire_false_on_different_body_test() {
+  let assert Ok(a) =
+    part.new(
+      headers: [#("X-Foo", "v")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<"a":utf8>>,
+    )
+  let assert Ok(b) =
+    part.new(
+      headers: [#("X-Foo", "v")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<"b":utf8>>,
+    )
+  part.equal_on_wire(a, b) |> should.be_false
+}
+
+pub fn equal_on_wire_false_on_different_headers_test() {
+  let assert Ok(a) =
+    part.new(
+      headers: [#("X-Foo", "1")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  let assert Ok(b) =
+    part.new(
+      headers: [#("X-Foo", "2")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  part.equal_on_wire(a, b) |> should.be_false
+}
+
+pub fn equal_on_wire_is_order_sensitive_on_headers_test() {
+  // RFC 7230 says repeated header names preserve relative order, so
+  // wire equality must reject reordered headers.
+  let assert Ok(a) =
+    part.new(
+      headers: [#("X-Trace", "first"), #("X-Trace", "second")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  let assert Ok(b) =
+    part.new(
+      headers: [#("X-Trace", "second"), #("X-Trace", "first")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<>>,
+    )
+  part.equal_on_wire(a, b) |> should.be_false
+}
+
+pub fn list_equal_on_wire_pairwise_test() {
+  let assert Ok(a) =
+    part.new(
+      headers: [#("X", "v")],
+      name: None,
+      filename: None,
+      content_type: None,
+      body: <<"x":utf8>>,
+    )
+  let assert Ok(b) =
+    part.new(
+      headers: [#("X", "v")],
+      name: Some("ignored"),
+      filename: None,
+      content_type: None,
+      body: <<"x":utf8>>,
+    )
+  part.list_equal_on_wire([a], [b]) |> should.be_true
+  part.list_equal_on_wire([], []) |> should.be_true
+  part.list_equal_on_wire([a], []) |> should.be_false
+  part.list_equal_on_wire([], [a]) |> should.be_false
+  part.list_equal_on_wire([a, a], [a]) |> should.be_false
+}
+
 pub fn header_lookup_uses_ascii_only_case_folding_test() {
   // Locale-sensitive lowercase folds Turkish I-with-dot to a lowercase i, but
   // ASCII case-insensitive comparison should not. Make sure non-ASCII names


### PR DESCRIPTION
## Summary

`Part` is opaque and stores `name` / `filename` / `content_type` as a
*cache* of values derived from the headers. Two `Part` values that
encode to byte-identical wire images can therefore differ under
structural `==` — `Part.new/5` accepts the cache verbatim from the
caller, while `parser.parse` derives it from the headers, so a
parse-after-encode round-trip almost always changes one of those
fields. Issue #27 asked for a wire-level equality predicate so
property-style round-trip tests don't have to project each `Part` to
`(all_headers, body)` by hand.

## Changes

- `src/multipartkit/part.gleam`: two new public predicates,
  `equal_on_wire/2` and `list_equal_on_wire/2`. The single-part
  predicate compares the headers list (preserving order, with
  case-sensitive name matching that mirrors RFC 7578 §4.2) and the
  body bytes; the cache fields are intentionally ignored. The
  list-lifted form requires equal length and pairwise
  `equal_on_wire`. Docstrings spell out which fields are
  intentionally ignored and why.
- `test/multipartkit/part_test.gleam`: five new tests cover the
  positive case (same wire content, different cache → equal),
  body mismatch, header value mismatch, header order sensitivity,
  and the list-lifted predicate's edge cases (both empty, one
  empty, length mismatch).
- `CHANGELOG.md`: `[Unreleased] / Added` entry.

## Design Decisions

- **Library-side equality, not a property-test helper.** Issue #27
  argues this convincingly: the *correct* equality on `Part`
  depends on RFC interpretation (header-name case sensitivity,
  RFC 7230 §3.2.4 OWS handling, etc.). Owning the predicate inside
  multipartkit means that interpretation lives in one place and
  consumers' tests don't have to update when the library evolves.
- **Header order is significant.** RFC 7230 keeps repeated
  header names in their relative wire order, so the predicate
  preserves that. A test pins it explicitly.
- **List-lifted variant.** The 1-part and 2-part fixtures dominate
  property-style round-trip tests; making consumers re-derive the
  list lifting from `equal_on_wire` would be the kind of
  off-by-one trap (length check vs `list.zip`) that exists to
  bite test code. Shipping it directly is a one-line public
  surface for an obvious convenience.
- **No reliance on `==` over the opaque type.** The predicate
  reaches into the headers and body explicitly via field access,
  not via a structural `==`-on-`Part` short-circuit, so a future
  internal-cache refactor (e.g. add a `params` cache, restructure
  `headers` storage) cannot silently drift the equality semantics.

## Limitations

- The cache fields (`name`, `filename`, `content_type`) are
  ignored by design. Callers who *do* want strict structural
  equality can keep using Gleam's `==` directly. Both predicates
  are documented as wire-level explicitly so there's no
  ambiguity.

Closes #27
