### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-07
+
 ### Added
 - **`part.equal_on_wire/2`** and **`part.list_equal_on_wire/2`** —
   structural equality predicates that compare two `Part` values (or

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.7.0"
+version = "0.8.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Added
- **`part.equal_on_wire/2`** and **`part.list_equal_on_wire/2`** —
  structural equality predicates that compare two `Part` values (or
  two `Part` lists) by their wire-level content. The comparison
  preserves header order and uses case-sensitive header-name
  matching (mirroring RFC 7578 §4.2), and intentionally ignores the
  convenience cache fields (`name`, `filename`, `content_type`)
  because those are derived from the headers and may differ between
  a `Part.new/5`-constructed value and a parsed `Part` even when
  the wire image is byte-identical. Previously, every consumer that
  wanted "do these encode to the same bytes?" had to project to
  `(all_headers, body)` themselves; multipartkit now owns that
  equality so the right RFC interpretation lives in one place and
  consumers can keep the projection out of property-test code. (#27)

### Fixed
- **`Part.new/5` now strips RFC 7230 §3.2.4 OWS** (space and
  horizontal tab) from the surrounding edges of every header value
  at construction time, mirroring what the parser does on the wire
  side. Previously, `Part.new(headers: [#("X-Foo", " spaced")], ...)`
  stored the value verbatim, but `encode → parse` produced
  `Some("spaced")` — the in-memory `Part` was no longer equal to
  itself across a wire round-trip. This was a property-test
  reliability problem (`forall_round_trip` would always fail) and
  forced consumers to wrap `Part` equality with a normalising
  projection. Whitespace *inside* a value (between tokens) is part
  of the data and is preserved verbatim. The constructor uses an
  RFC-7230-specific OWS predicate (only `0x20` and `0x09`) rather
  than `string.trim`, which would also strip Unicode whitespace.
  This is a behaviour change for `Part` values that explicitly
  carried surrounding whitespace; the wire image already lost that
  data — the in-memory model now matches. (#29)

### Security
- **multipart CRLF / NUL injection in `Part.new/5`** —
  `multipartkit/part.new/5` now validates header names and values
  before constructing a `Part` and returns
  `Result(Part, MultipartError)` instead of `Part`. Header values
  containing `\r`, `\n`, or NUL are rejected with
  `Error(InvalidHeaderValue(name, value))`; header names containing
  any of those bytes or a `:` are rejected with
  `Error(InvalidHeaderName(name))`. Previously, an attacker who
  controlled a header value could smuggle additional header lines
  into the encoded wire image — the multipart variant of CRLF
  response splitting (RFC 9110 §5.5 disallows these bytes in
  `field-value`). Two new variants in `MultipartError`,
  `InvalidHeaderName` and `InvalidHeaderValue`, surface the rejection.
  Internal callers (`form.add_field`, `form.add_file*`,
  `parser.parse`) already sanitise or pre-validate their input and
  use a new `@internal` `part.unchecked_new` helper that skips the
  check; no behaviour change for callers of the `form` builder. (#28)

### Breaking change (security fix)
- `Part.new/5` signature is now
  `Result(Part, MultipartError)` instead of `Part`. Existing
  call sites must `use part <- result.try(part.new(...))` (or
  `let assert Ok(part) = part.new(...)` when input is statically
  safe). The bug closed by this change is severe enough to justify
  a major bump on its own.
