### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-08
+
 ### Security
 - **`encoder.encode/2` and `multipartkit.encode/2` now validate the
   caller-supplied boundary** against RFC 2046 §5.1.1 before producing
@@ -14,13 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   raw bytes verbatim, so a caller who built the boundary from data
   (request id, user-agent fragment, etc.) could produce a wire image
   whose framing bytes contain `CR` / `LF` / `--BOUNDARY` collisions and
-  splice forged headers ahead of the first real part. The encode-side
-  companion to the existing `Part.new/5` header guard (#28). The
-  validator that already lived in `multipartkit/header` (and that the
-  *parse* path consulted) is now wired into the *encode* path too —
-  one source of truth, one rejection set. `encoder.encode_stream/2`
-  surfaces the same diagnostic on the first emission of the returned
-  yielder. (#34)
+  splice forged headers ahead of the first real part. This release adds
+  the encode-side companion to the existing `Part.new/5` header guard
+  (#28): the validator that already lived in `multipartkit/header` (and
+  that the *parse* path consulted) is now wired into the *encode* path
+  too — one source of truth, one rejection set.
+  `encoder.encode_stream/2` surfaces the same diagnostic on the first
+  emission of the returned yielder. (#34)
 
 ### Changed
 - **Breaking (`encoder.encode/2`, `multipartkit.encode/2`)**: now

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.8.0"
+version = "0.9.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Security
- **`encoder.encode/2` and `multipartkit.encode/2` now validate the
  caller-supplied boundary** against RFC 2046 §5.1.1 before producing
  bytes. Previously the encoder accepted any `String` and emitted the
  raw bytes verbatim, so a caller who built the boundary from data
  (request id, user-agent fragment, etc.) could produce a wire image
  whose framing bytes contain `CR` / `LF` / `--BOUNDARY` collisions and
  splice forged headers ahead of the first real part. This release adds
  the encode-side companion to the existing `Part.new/5` header guard
  (#28): the validator that already lived in `multipartkit/header` (and
  that the *parse* path consulted) is now wired into the *encode* path
  too — one source of truth, one rejection set.
  `encoder.encode_stream/2` surfaces the same diagnostic on the first
  emission of the returned yielder. (#34)

### Changed
- **Breaking (`encoder.encode/2`, `multipartkit.encode/2`)**: now
  return `Result(BitArray, MultipartError)` instead of `BitArray`.
  Callers updating: `let assert Ok(body) = multipartkit.encode(b, ps)`
  for the legacy signature when the boundary is hard-coded. Boundaries
  generated by `encode_form` / `generate_boundary` always pass the
  validator, so internal use sites are unaffected. (#34)

### Added
- **`multipartkit/header.validate_boundary/1`** is now part of the
  public API. Useful when callers want to validate a boundary
  independently of the encode call (e.g. to surface the diagnostic
  earlier in a request pipeline). The same predicate gates both the
  parse-side `header.boundary/1` and the encode-side `encoder.encode/2`,
  so "would parse round-trip this?" and "will encode emit this?" agree.
  (#34)
