### PR TITLE
fix(part): synthesise Content-Disposition / Content-Type from cache values in new/5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`part.new/5`** now synthesises the `Content-Disposition` and / or
+  `Content-Type` headers on the way through the constructor when the
+  caller passes `name` / `filename` / `content_type` cache values without
+  the matching header entry in `headers`. Previously those parameters
+  were stored as memos only — the encoded wire image omitted the
+  corresponding header lines, so a `multipartkit.encode |> parse`
+  round-trip dropped `name`, `filename`, and `content_type` to `None`.
+  The synthesised `Content-Disposition` value uses the same shape that
+  `multipartkit/form.add_field` and `add_file` emit (legacy
+  `filename="..."` for ASCII filenames, RFC 5987 `filename*=UTF-8''...`
+  with an ASCII fallback for non-ASCII filenames). When the relevant
+  header is already present in `headers`, the caller's explicit value
+  wins — synthesis does not duplicate or replace it. The existing CRLF
+  / NUL guard now also applies to `name`, `filename`, and `content_type`
+  because they may be promoted to header values; offending inputs
+  surface as `Error(InvalidHeaderValue("Content-Disposition" |
+  "Content-Type", value))` rather than silently emitting an off-spec
+  wire image. (#37)
+
 ## [0.9.0] - 2026-05-08
 
 ### Security

--- a/src/multipartkit/form.gleam
+++ b/src/multipartkit/form.gleam
@@ -1,10 +1,7 @@
-import gleam/bit_array
-import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
-import gleam/result
-import gleam/string
 import multipartkit/infer
+import multipartkit/internal/disposition
 import multipartkit/part.{type Part}
 
 /// Opaque builder for multipart/form-data messages.
@@ -31,14 +28,14 @@ pub fn new() -> Form {
 /// round-trip would produce. Use `unsafe_add_part` if byte-exact
 /// preservation is required.
 pub fn add_field(form: Form, name: String, value: String) -> Form {
-  let safe_name = sanitize_value(name)
-  let disposition = #(
+  let safe_name = disposition.sanitize_value(name)
+  let header = #(
     "Content-Disposition",
-    "form-data; name=" <> quote(safe_name),
+    disposition.build_form_data_value(safe_name, None),
   )
   let new_part =
     part.unchecked_new(
-      headers: [disposition],
+      headers: [header],
       name: Some(safe_name),
       filename: None,
       content_type: None,
@@ -132,14 +129,12 @@ fn build_file_part(
   content_type: String,
   body: BitArray,
 ) -> Part {
-  let safe_name = sanitize_value(name)
-  let safe_filename = sanitize_value(filename)
-  let safe_content_type = sanitize_value(content_type)
+  let safe_name = disposition.sanitize_value(name)
+  let safe_filename = disposition.sanitize_value(filename)
+  let safe_content_type = disposition.sanitize_value(content_type)
   let disposition_header = #(
     "Content-Disposition",
-    "form-data; name="
-      <> quote(safe_name)
-      <> filename_disposition_params(safe_filename),
+    disposition.build_form_data_value(safe_name, Some(safe_filename)),
   )
   let content_type_header = #("Content-Type", safe_content_type)
   part.unchecked_new(
@@ -149,173 +144,4 @@ fn build_file_part(
     content_type: Some(safe_content_type),
     body: body,
   )
-}
-
-/// Build the `; filename=...` portion of a Content-Disposition header
-/// for a file part.
-///
-/// For ASCII-safe filenames (every code point is printable US-ASCII
-/// per RFC 7230 §3.2.4) the legacy `filename="..."` form is sufficient
-/// and is emitted unchanged.
-///
-/// For filenames that contain bytes outside that range, the legacy
-/// form would produce a header value that violates RFC 7230 §3.2.4 and
-/// is mangled or rejected by strict HTTP intermediaries. We emit BOTH:
-///
-/// - `filename="<ascii-fallback>"` — non-ASCII code points replaced
-///   with `_`. Lets pre-RFC-5987 clients still see a sensible name.
-/// - `filename*=UTF-8''<percent-encoded>` — RFC 5987 §3.2.1 / RFC 6266
-///   §4.3 form, faithful round-trip for spec-aware parsers.
-///
-/// RFC 5987 §3.2.2: when both forms are present, the `*=` form takes
-/// precedence — multipartkit's own `content_disposition.parse` already
-/// honours that ordering, as do all browsers and the major HTTP
-/// servers.
-fn filename_disposition_params(filename: String) -> String {
-  case is_ascii_safe(filename) {
-    True -> "; filename=" <> quote(filename)
-    False ->
-      "; filename="
-      <> quote(ascii_fallback(filename))
-      <> "; filename*=UTF-8''"
-      <> percent_encode_rfc5987(filename)
-  }
-}
-
-/// True iff every code point in `s` is printable US-ASCII (0x20-0x7E)
-/// or HTAB. Matches the subset of bytes RFC 7230 §3.2.4 admits as
-/// header field values.
-fn is_ascii_safe(s: String) -> Bool {
-  is_ascii_safe_loop(bit_array.from_string(s))
-}
-
-fn is_ascii_safe_loop(bytes: BitArray) -> Bool {
-  case bytes {
-    <<>> -> True
-    <<b, rest:bytes>> ->
-      case b == 0x09 || { b >= 0x20 && b <= 0x7E } {
-        True -> is_ascii_safe_loop(rest)
-        False -> False
-      }
-    _ -> False
-  }
-}
-
-/// Replace every non-ASCII-safe code point in `s` with `_` so the
-/// result is safe for use inside a legacy `filename="..."`. Used as
-/// the pre-RFC-5987 fallback alongside `filename*=`.
-fn ascii_fallback(s: String) -> String {
-  ascii_fallback_loop(string.to_graphemes(s), "")
-}
-
-fn ascii_fallback_loop(remaining: List(String), acc: String) -> String {
-  case remaining {
-    [] -> acc
-    [grapheme, ..rest] ->
-      case is_ascii_safe(grapheme) {
-        True -> ascii_fallback_loop(rest, acc <> grapheme)
-        False -> ascii_fallback_loop(rest, acc <> "_")
-      }
-  }
-}
-
-/// Percent-encode the UTF-8 byte representation of `s` per RFC 5987
-/// §3.2.1 attr-char. Bytes that match the attr-char production
-/// (`ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" /
-/// "_" / "`" / "|" / "~"`) pass through unencoded; every other byte
-/// is emitted as `%HH` with uppercase hex digits.
-fn percent_encode_rfc5987(s: String) -> String {
-  percent_encode_loop(bit_array.from_string(s), "")
-}
-
-fn percent_encode_loop(bytes: BitArray, acc: String) -> String {
-  case bytes {
-    <<>> -> acc
-    <<b, rest:bytes>> -> {
-      // attr-char bytes pass through as their literal ASCII character;
-      // every other byte (including the high bytes of multi-byte UTF-8
-      // sequences) is emitted as `%HH`. `bit_array.to_string` is used
-      // for the attr-char branch and falls back to the percent-byte
-      // form on any conversion error — every byte for which
-      // `is_attr_char` returns True is in the printable US-ASCII range
-      // and converts cleanly, so the fallback is purely for type
-      // safety.
-      let chunk = case is_attr_char(b) {
-        False -> percent_byte(b)
-        True -> bit_array.to_string(<<b>>) |> result.unwrap(percent_byte(b))
-      }
-      percent_encode_loop(rest, acc <> chunk)
-    }
-    _ -> acc
-  }
-}
-
-fn is_attr_char(b: Int) -> Bool {
-  // ALPHA / DIGIT
-  { b >= 0x41 && b <= 0x5A }
-  || { b >= 0x61 && b <= 0x7A }
-  || { b >= 0x30 && b <= 0x39 }
-  // ! # $ & + - . ^ _ ` | ~
-  || b == 0x21
-  || b == 0x23
-  || b == 0x24
-  || b == 0x26
-  || b == 0x2B
-  || b == 0x2D
-  || b == 0x2E
-  || b == 0x5E
-  || b == 0x5F
-  || b == 0x60
-  || b == 0x7C
-  || b == 0x7E
-}
-
-fn percent_byte(b: Int) -> String {
-  "%" <> hex_digit(b / 16) <> hex_digit(b % 16)
-}
-
-fn hex_digit(n: Int) -> String {
-  case n {
-    0 -> "0"
-    1 -> "1"
-    2 -> "2"
-    3 -> "3"
-    4 -> "4"
-    5 -> "5"
-    6 -> "6"
-    7 -> "7"
-    8 -> "8"
-    9 -> "9"
-    10 -> "A"
-    11 -> "B"
-    12 -> "C"
-    13 -> "D"
-    14 -> "E"
-    15 -> "F"
-    _ -> int.to_string(n)
-  }
-}
-
-/// Strip CR, LF, and NUL from `value`. Used to neutralise header injection
-/// in any value that ends up on a header line — `name`, `filename`, and
-/// `content_type`.
-fn sanitize_value(value: String) -> String {
-  value
-  |> string.replace(each: "\r\n", with: "")
-  |> string.replace(each: "\r", with: "")
-  |> string.replace(each: "\n", with: "")
-  |> string.replace(each: "\u{0000}", with: "")
-}
-
-fn quote(value: String) -> String {
-  "\"" <> escape_quoted(value, "") <> "\""
-}
-
-fn escape_quoted(remaining: String, acc: String) -> String {
-  case string.pop_grapheme(remaining) {
-    Error(Nil) -> acc
-    Ok(#("\\", rest)) -> escape_quoted(rest, acc <> "\\\\")
-    Ok(#("\"", rest)) -> escape_quoted(rest, acc <> "\\\"")
-    Ok(#(other, rest)) -> escape_quoted(rest, acc <> other)
-  }
 }

--- a/src/multipartkit/internal/disposition.gleam
+++ b/src/multipartkit/internal/disposition.gleam
@@ -1,0 +1,172 @@
+//// Internal: helpers for building `Content-Disposition` header values
+//// (the `form-data; name="..."[; filename=...]` shape) and for stripping
+//// CR / LF / NUL bytes that would otherwise smuggle additional header
+//// lines into the encoded wire image. Shared by `multipartkit/form` (which
+//// builds parts from raw values) and `multipartkit/part` (which synthesises
+//// missing headers when `new/5` is given `name` / `filename` /
+//// `content_type` cache values without the corresponding header entries).
+
+import gleam/bit_array
+import gleam/int
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
+
+/// Build the full `Content-Disposition` header value for a `multipart/form-data`
+/// part with the given `name` and optional `filename`. The output mirrors what
+/// `multipartkit/form.add_field` and `add_file` emit:
+///
+/// - ASCII-safe filenames use the legacy `filename="..."` form.
+/// - Filenames with non-ASCII bytes additionally emit the RFC 5987
+///   `filename*=UTF-8''<percent-encoded>` form (with an ASCII fallback in
+///   the legacy slot).
+///
+/// Inputs are NOT sanitised here — callers are expected to either sanitise
+/// (`form.gleam`) or reject (`part.gleam`) CR / LF / NUL bytes before
+/// reaching this builder.
+pub fn build_form_data_value(name: String, filename: Option(String)) -> String {
+  let base = "form-data; name=" <> quote(name)
+  case filename {
+    None -> base
+    Some(fname) -> base <> filename_disposition_params(fname)
+  }
+}
+
+/// Strip CR, LF, and NUL from `value`. Used by `multipartkit/form` to
+/// silently neutralise header injection in any value that ends up on a
+/// header line. `multipartkit/part.new/5` does NOT use this — it rejects
+/// these bytes outright.
+pub fn sanitize_value(value: String) -> String {
+  value
+  |> string.replace(each: "\r\n", with: "")
+  |> string.replace(each: "\r", with: "")
+  |> string.replace(each: "\n", with: "")
+  |> string.replace(each: "\u{0000}", with: "")
+}
+
+/// True iff `value` contains no CR, LF, or NUL bytes — the bytes that
+/// would split a header value into multiple wire lines.
+pub fn has_header_breaking_bytes(value: String) -> Bool {
+  string.contains(value, "\r")
+  || string.contains(value, "\n")
+  || string.contains(value, "\u{0000}")
+}
+
+fn filename_disposition_params(filename: String) -> String {
+  case is_ascii_safe(filename) {
+    True -> "; filename=" <> quote(filename)
+    False ->
+      "; filename="
+      <> quote(ascii_fallback(filename))
+      <> "; filename*=UTF-8''"
+      <> percent_encode_rfc5987(filename)
+  }
+}
+
+fn is_ascii_safe(s: String) -> Bool {
+  is_ascii_safe_loop(bit_array.from_string(s))
+}
+
+fn is_ascii_safe_loop(bytes: BitArray) -> Bool {
+  case bytes {
+    <<>> -> True
+    <<b, rest:bytes>> ->
+      case b == 0x09 || { b >= 0x20 && b <= 0x7E } {
+        True -> is_ascii_safe_loop(rest)
+        False -> False
+      }
+    _ -> False
+  }
+}
+
+fn ascii_fallback(s: String) -> String {
+  ascii_fallback_loop(string.to_graphemes(s), "")
+}
+
+fn ascii_fallback_loop(remaining: List(String), acc: String) -> String {
+  case remaining {
+    [] -> acc
+    [grapheme, ..rest] ->
+      case is_ascii_safe(grapheme) {
+        True -> ascii_fallback_loop(rest, acc <> grapheme)
+        False -> ascii_fallback_loop(rest, acc <> "_")
+      }
+  }
+}
+
+fn percent_encode_rfc5987(s: String) -> String {
+  percent_encode_loop(bit_array.from_string(s), "")
+}
+
+fn percent_encode_loop(bytes: BitArray, acc: String) -> String {
+  case bytes {
+    <<>> -> acc
+    <<b, rest:bytes>> -> {
+      let chunk = case is_attr_char(b) {
+        False -> percent_byte(b)
+        True -> bit_array.to_string(<<b>>) |> result.unwrap(percent_byte(b))
+      }
+      percent_encode_loop(rest, acc <> chunk)
+    }
+    _ -> acc
+  }
+}
+
+fn is_attr_char(b: Int) -> Bool {
+  // ALPHA / DIGIT
+  { b >= 0x41 && b <= 0x5A }
+  || { b >= 0x61 && b <= 0x7A }
+  || { b >= 0x30 && b <= 0x39 }
+  // ! # $ & + - . ^ _ ` | ~
+  || b == 0x21
+  || b == 0x23
+  || b == 0x24
+  || b == 0x26
+  || b == 0x2B
+  || b == 0x2D
+  || b == 0x2E
+  || b == 0x5E
+  || b == 0x5F
+  || b == 0x60
+  || b == 0x7C
+  || b == 0x7E
+}
+
+fn percent_byte(b: Int) -> String {
+  "%" <> hex_digit(b / 16) <> hex_digit(b % 16)
+}
+
+fn hex_digit(n: Int) -> String {
+  case n {
+    0 -> "0"
+    1 -> "1"
+    2 -> "2"
+    3 -> "3"
+    4 -> "4"
+    5 -> "5"
+    6 -> "6"
+    7 -> "7"
+    8 -> "8"
+    9 -> "9"
+    10 -> "A"
+    11 -> "B"
+    12 -> "C"
+    13 -> "D"
+    14 -> "E"
+    15 -> "F"
+    _ -> int.to_string(n)
+  }
+}
+
+fn quote(value: String) -> String {
+  "\"" <> escape_quoted(value, "") <> "\""
+}
+
+fn escape_quoted(remaining: String, acc: String) -> String {
+  case string.pop_grapheme(remaining) {
+    Error(Nil) -> acc
+    Ok(#("\\", rest)) -> escape_quoted(rest, acc <> "\\\\")
+    Ok(#("\"", rest)) -> escape_quoted(rest, acc <> "\\\"")
+    Ok(#(other, rest)) -> escape_quoted(rest, acc <> other)
+  }
+}

--- a/src/multipartkit/part.gleam
+++ b/src/multipartkit/part.gleam
@@ -6,6 +6,7 @@ import gleam/string
 import multipartkit/error.{
   type MultipartError, InvalidHeaderName, InvalidHeaderValue,
 }
+import multipartkit/internal/disposition
 import multipartkit/internal/text
 
 /// A parsed multipart part.
@@ -33,8 +34,9 @@ import multipartkit/internal/text
 ///
 /// `name`, `filename`, and `content_type` are convenience caches derived from
 /// `Content-Disposition` and `Content-Type` headers per the field/file
-/// detection rules. They are not re-derived automatically when a caller
-/// constructs a `Part` manually with `new/5`.
+/// detection rules. When `new/5` is given non-`None` cache values without
+/// the corresponding header entry in `headers`, the header is synthesised
+/// so the cached value also appears on the wire (see `new/5` for details).
 pub opaque type Part {
   Part(
     headers: List(#(String, String)),
@@ -47,9 +49,26 @@ pub opaque type Part {
 
 /// Construct a `Part`.
 ///
-/// The `name`, `filename`, and `content_type` fields are not re-derived
-/// from the `headers` list — pass the values you expect callers to see,
-/// or use `parser.parse` for automatic derivation.
+/// The `name`, `filename`, and `content_type` parameters double as wire
+/// instructions: when one of them is `Some(_)` and the corresponding header
+/// is absent from `headers`, the constructor synthesises the missing header
+/// (matching the shape `multipartkit/form.add_field` / `add_file` would
+/// emit) so the cached value also appears in the encoded wire image and
+/// survives a `multipartkit.encode |> multipartkit.parse` round trip.
+///
+/// Synthesis rules:
+///
+/// - `name: Some(n)` and no `Content-Disposition` header → prepends
+///   `Content-Disposition: form-data; name="n"` (with `; filename=...`
+///   appended when `filename` is also `Some(_)`, using the RFC 5987
+///   `filename*=` form for non-ASCII filenames).
+/// - `content_type: Some(ct)` and no `Content-Type` header → prepends
+///   `Content-Type: ct`.
+/// - `filename: Some(_)` without `name` does not synthesise a
+///   `Content-Disposition` (RFC 7578 §4.2 requires `name`); the value is
+///   stored as the cache only.
+/// - When the relevant header IS present in `headers`, the constructor
+///   leaves the headers list untouched — the caller's explicit header wins.
 ///
 /// Header names and values are validated to prevent CRLF / NUL injection
 /// into the encoded wire image. A header value that contains `\r`, `\n`,
@@ -57,9 +76,12 @@ pub opaque type Part {
 /// additional header lines into the encoded part — the multipart variant
 /// of CRLF response splitting (RFC 9110 §5.5 disallows these bytes in
 /// `field-value`). Header names additionally cannot contain `:` (would
-/// split the header at parse time). The constructor rejects these inputs
-/// with `Error(InvalidHeaderName(_))` / `Error(InvalidHeaderValue(_, _))`
-/// rather than silently emitting an off-spec wire image.
+/// split the header at parse time). The same CRLF / NUL guard applies to
+/// `name`, `filename`, and `content_type` because they may be promoted to
+/// header values by the synthesis rules above. The constructor rejects
+/// these inputs with `Error(InvalidHeaderName(_))` /
+/// `Error(InvalidHeaderValue(_, _))` rather than silently emitting an
+/// off-spec wire image.
 pub fn new(
   headers headers: List(#(String, String)),
   name name: Option(String),
@@ -68,8 +90,13 @@ pub fn new(
   body body: BitArray,
 ) -> Result(Part, MultipartError) {
   use normalised <- result.try(validate_and_normalise_headers(headers, []))
+  use _ <- result.try(reject_breaking_bytes("Content-Disposition", name))
+  use _ <- result.try(reject_breaking_bytes("Content-Disposition", filename))
+  use _ <- result.try(reject_breaking_bytes("Content-Type", content_type))
+  let synthesised =
+    synthesise_missing_headers(normalised, name, filename, content_type)
   Ok(Part(
-    headers: normalised,
+    headers: synthesised,
     name: name,
     filename: filename,
     content_type: content_type,
@@ -123,6 +150,77 @@ fn validate_and_normalise_headers(
       )
       validate_and_normalise_headers(rest, [#(name, trim_ows(value)), ..acc])
     }
+  }
+}
+
+/// If `value` is `Some(v)` and `v` contains a CR / LF / NUL byte, surface
+/// it as `InvalidHeaderValue(header_name, v)` so the user sees the same
+/// error shape they would get for the raw header pair. `header_name` is
+/// the wire header that synthesis would derive from this parameter
+/// (`Content-Disposition` for `name` / `filename`, `Content-Type` for
+/// `content_type`); reusing it makes the error point at the actual
+/// failure mode without inventing a new error variant.
+fn reject_breaking_bytes(
+  header_name: String,
+  value: Option(String),
+) -> Result(Nil, MultipartError) {
+  case value {
+    None -> Ok(Nil)
+    Some(v) ->
+      case disposition.has_header_breaking_bytes(v) {
+        True -> Error(InvalidHeaderValue(header_name, v))
+        False -> Ok(Nil)
+      }
+  }
+}
+
+/// Prepend `Content-Disposition` (when `name` is `Some(_)` and missing
+/// from `existing`) and `Content-Type` (when `content_type` is `Some(_)`
+/// and missing from `existing`) to mirror what the wire-side parser would
+/// derive from those headers. Header order is `[Content-Disposition,
+/// Content-Type, ...existing]`, matching what `multipartkit/form.add_file`
+/// emits.
+fn synthesise_missing_headers(
+  existing: List(#(String, String)),
+  name: Option(String),
+  filename: Option(String),
+  content_type: Option(String),
+) -> List(#(String, String)) {
+  let with_content_type = case content_type {
+    None -> existing
+    Some(ct) ->
+      case has_header_ci(existing, "content-type") {
+        True -> existing
+        False -> [#("Content-Type", ct), ..existing]
+      }
+  }
+  case name {
+    None -> with_content_type
+    Some(n) ->
+      case has_header_ci(with_content_type, "content-disposition") {
+        True -> with_content_type
+        False -> [
+          #(
+            "Content-Disposition",
+            disposition.build_form_data_value(n, filename),
+          ),
+          ..with_content_type
+        ]
+      }
+  }
+}
+
+fn has_header_ci(
+  headers: List(#(String, String)),
+  lowercase_name: String,
+) -> Bool {
+  case headers {
+    [] -> False
+    [#(k, _), ..rest] ->
+      case text.equals_ci(k, lowercase_name) {
+        True -> True
+        False -> has_header_ci(rest, lowercase_name)
+      }
   }
 }
 

--- a/test/multipartkit/part_test.gleam
+++ b/test/multipartkit/part_test.gleam
@@ -1,6 +1,8 @@
 import gleam/option.{None, Some}
 import gleeunit/should
+import multipartkit/encoder
 import multipartkit/error.{InvalidHeaderName, InvalidHeaderValue}
+import multipartkit/parser
 import multipartkit/part.{type Part}
 
 fn sample() -> Part {
@@ -276,9 +278,16 @@ pub fn equal_on_wire_is_order_sensitive_on_headers_test() {
 }
 
 pub fn list_equal_on_wire_pairwise_test() {
+  // Both parts carry the same `Content-Disposition` on the headers list,
+  // so synthesis is a no-op for both regardless of the `name` cache.
+  // `equal_on_wire` ignores the cache and the headers / body match —
+  // pairwise list equality therefore returns True.
   let assert Ok(a) =
     part.new(
-      headers: [#("X", "v")],
+      headers: [
+        #("Content-Disposition", "form-data; name=\"ignored\""),
+        #("X", "v"),
+      ],
       name: None,
       filename: None,
       content_type: None,
@@ -286,7 +295,10 @@ pub fn list_equal_on_wire_pairwise_test() {
     )
   let assert Ok(b) =
     part.new(
-      headers: [#("X", "v")],
+      headers: [
+        #("Content-Disposition", "form-data; name=\"ignored\""),
+        #("X", "v"),
+      ],
       name: Some("ignored"),
       filename: None,
       content_type: None,
@@ -297,6 +309,154 @@ pub fn list_equal_on_wire_pairwise_test() {
   part.list_equal_on_wire([a], []) |> should.be_false
   part.list_equal_on_wire([], [a]) |> should.be_false
   part.list_equal_on_wire([a, a], [a]) |> should.be_false
+}
+
+pub fn new_synthesises_content_disposition_when_name_is_some_test() {
+  // #37: a `Part` constructed with `name: Some("code")` and an empty
+  // `headers` list used to encode without a `Content-Disposition` line,
+  // so a parse-after-encode round trip dropped `name` to `None`. The
+  // constructor now prepends a `Content-Disposition: form-data; name=...`
+  // header so the cache survives the round trip.
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: Some("code"),
+      filename: None,
+      content_type: None,
+      body: <<"hi":utf8>>,
+    )
+  part.header(p, "Content-Disposition")
+  |> should.equal(Some("form-data; name=\"code\""))
+}
+
+pub fn new_synthesises_content_disposition_with_filename_test() {
+  // When both `name` and `filename` are passed, the synthesised
+  // `Content-Disposition` carries the filename parameter too — same
+  // shape `multipartkit/form.add_file` would have written.
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: Some("upload"),
+      filename: Some("a.bin"),
+      content_type: None,
+      body: <<>>,
+    )
+  part.header(p, "Content-Disposition")
+  |> should.equal(Some("form-data; name=\"upload\"; filename=\"a.bin\""))
+}
+
+pub fn new_synthesises_filename_star_for_non_ascii_test() {
+  // Non-ASCII filenames must use the RFC 5987 `filename*=UTF-8''...`
+  // form (with an ASCII fallback in the legacy slot) — same encoding
+  // `multipartkit/form.add_file` uses.
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: Some("upload"),
+      filename: Some("日本語.txt"),
+      content_type: None,
+      body: <<>>,
+    )
+  part.header(p, "Content-Disposition")
+  |> should.equal(Some(
+    "form-data; name=\"upload\"; filename=\"___.txt\"; filename*=UTF-8''%E6%97%A5%E6%9C%AC%E8%AA%9E.txt",
+  ))
+}
+
+pub fn new_synthesises_content_type_when_some_test() {
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: None,
+      filename: None,
+      content_type: Some("text/plain"),
+      body: <<>>,
+    )
+  part.header(p, "Content-Type") |> should.equal(Some("text/plain"))
+}
+
+pub fn new_does_not_synthesise_when_header_already_present_test() {
+  // The caller's explicit `Content-Disposition` header wins — synthesis
+  // does NOT replace or duplicate it. Same for `Content-Type`.
+  let assert Ok(p) =
+    part.new(
+      headers: [
+        #("Content-Disposition", "attachment; filename=\"raw.bin\""),
+        #("Content-Type", "application/x-custom"),
+      ],
+      name: Some("ignored"),
+      filename: Some("ignored.bin"),
+      content_type: Some("text/plain"),
+      body: <<>>,
+    )
+  part.headers(p, "Content-Disposition")
+  |> should.equal(["attachment; filename=\"raw.bin\""])
+  part.headers(p, "Content-Type") |> should.equal(["application/x-custom"])
+}
+
+pub fn new_does_not_synthesise_disposition_when_only_filename_is_some_test() {
+  // RFC 7578 §4.2 requires `name=` on form-data parts. Without `name`
+  // there is no valid Content-Disposition shape to synthesise, so the
+  // headers list stays empty and `filename` is kept as a cache only.
+  let assert Ok(p) =
+    part.new(
+      headers: [],
+      name: None,
+      filename: Some("only.bin"),
+      content_type: None,
+      body: <<>>,
+    )
+  part.all_headers(p) |> should.equal([])
+  part.filename(p) |> should.equal(Some("only.bin"))
+}
+
+pub fn new_round_trip_preserves_name_filename_content_type_test() {
+  // The exact reproducer from #37: a `Part` built with cache values and
+  // an empty `headers` list now survives `encode |> parse` with the
+  // cache intact.
+  let assert Ok(original) =
+    part.new(
+      headers: [],
+      name: Some("code"),
+      filename: None,
+      content_type: Some("text/plain"),
+      body: <<"hello":utf8>>,
+    )
+  let assert Ok(wire) = encoder.encode("BOUNDARY42", [original])
+  let assert Ok([parsed]) =
+    parser.parse(wire, "multipart/form-data; boundary=BOUNDARY42")
+  part.name(parsed) |> should.equal(Some("code"))
+  part.content_type(parsed) |> should.equal(Some("text/plain"))
+  part.body(parsed) |> should.equal(<<"hello":utf8>>)
+}
+
+pub fn new_rejects_lf_in_synthesised_name_test() {
+  // The CR / LF / NUL guard applies to `name` because the constructor
+  // promotes it to a `Content-Disposition` header value when the header
+  // is absent; allowing CR / LF would inject an additional header line.
+  part.new(
+    headers: [],
+    name: Some("ok\nX-Injected: bad"),
+    filename: None,
+    content_type: None,
+    body: <<>>,
+  )
+  |> should.equal(
+    Error(InvalidHeaderValue("Content-Disposition", "ok\nX-Injected: bad")),
+  )
+}
+
+pub fn new_rejects_crlf_in_synthesised_content_type_test() {
+  part.new(
+    headers: [],
+    name: None,
+    filename: None,
+    content_type: Some("text/plain\r\nX-Injected: bad"),
+    body: <<>>,
+  )
+  |> should.equal(
+    Error(InvalidHeaderValue("Content-Type", "text/plain\r\nX-Injected: bad")),
+  )
 }
 
 pub fn header_lookup_uses_ascii_only_case_folding_test() {


### PR DESCRIPTION
## Summary

`part.new(name: Some(_), filename: ..., content_type: ..., headers: [], ...)` used to keep the cache parameters as memos only. The encoded wire image omitted the corresponding `Content-Disposition` / `Content-Type` lines, so a `multipartkit.encode |> parse` round trip dropped `name`, `filename`, and `content_type` to `None`. This made the constructor's labelled parameters look like instructions when they were really just notes.

## Changes

- `part.new/5` now synthesises a `Content-Disposition` header when `name: Some(_)` is passed and the headers list lacks one, and a `Content-Type` header when `content_type: Some(_)` is passed and the headers list lacks one. The synthesised `Content-Disposition` value reuses the form-data shape from `multipartkit/form.add_field` / `add_file` (legacy `filename="..."` for ASCII filenames, RFC 5987 `filename*=UTF-8''...` with an ASCII fallback for non-ASCII).
- Caller-provided `Content-Disposition` / `Content-Type` headers in `headers` always win — synthesis does not duplicate or override them.
- `filename: Some(_)` without `name` does not synthesise (RFC 7578 §4.2 requires `name` on form-data parts); the value is kept as a cache only.
- The CRLF / NUL guard now also covers `name`, `filename`, and `content_type` because they may be promoted to header values by the synthesis rules. Offending inputs surface as `Error(InvalidHeaderValue("Content-Disposition" | "Content-Type", value))`.
- Header-building helpers (form-data disposition value, ASCII safety check, RFC 5987 percent encoding, CR/LF/NUL sanitiser) extracted from `multipartkit/form` to a new internal module `multipartkit/internal/disposition` so `part` and `form` share one canonical encoder.

## Design Decisions

- **Option A from the issue, not Option B.** Adding documentation that redirects callers to `form.add_field` / `add_file` would still leave the constructor's parameter names looking like instructions. Synthesis closes the gap at the call site users actually wrote.
- **Synthesised headers prepend, not append.** Order is `[Content-Disposition, Content-Type, ...caller-headers]`, matching what `form.add_file` writes.
- **Strict validation, not silent sanitisation.** `form.add_field` silently strips CR/LF/NUL because it sits behind a higher-level builder. `part.new/5` already rejects these bytes in the headers list (see #28 / the existing `InvalidHeaderValue` guard); the same guard now covers the cache parameters for consistency.

## Test plan

- [x] `gleam test` (Erlang target) — 204 passed
- [x] `gleam test --target javascript` — 204 passed
- [x] `gleam build --warnings-as-errors` (Erlang and JavaScript)
- [x] `gleam check`
- [x] `gleam run -m glinter`
- [x] `gleam format --check src/ test/`
- [x] New regression tests cover: ASCII synthesis, name-only, name+filename, RFC 5987 fallback, content_type-only, no-override-when-present, name-less filename (no synthesis), full encode→parse round trip from the issue reproducer, and CRLF rejection on synthesised values.
- [x] Updated `list_equal_on_wire_pairwise_test` to use a shared explicit `Content-Disposition` so synthesis is a no-op for both parts (the test's intent — cache differs but wire matches — is preserved).

Closes #37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field metadata preservation through encode/parse operations by automatically synthesizing missing headers with validation for invalid characters and RFC 5987 non-ASCII filename support.

* **Tests**
  * Added test coverage for header synthesis and round-trip preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->