### PR TITLE
feat(form): add add_field_strict / add_file_strict for typed-error rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`multipartkit/form`**: `add_field_strict` and `add_file_strict`
+  are the typed-error counterparts of the existing
+  `add_field` / `add_file`. The non-strict variants silently strip
+  CR / LF / NUL bytes from the values that flow into header lines
+  (so `add_field("name\n", _)` produces a part with `name=""`,
+  and `add_file(_, "fi\nle.png", _, _)` concatenates the two
+  halves into the *different valid filename* `"file.png"` — the
+  authorisation-relevant identifier change described in #41).
+  The strict variants surface the bad input as
+  `Error(NameContainsControlBytes(value:))` /
+  `Error(FilenameContainsControlBytes(value:))` /
+  `Error(ContentTypeContainsControlBytes(value:))` so callers
+  passing user-typed or upstream data can render an actionable
+  error rather than producing the wrong wire silently. Add the
+  matching `FormError` type (re-exported from the top-level
+  `multipartkit` module). The existing non-strict variants keep
+  their void return for backward compatibility, with doc-comments
+  updated to point at the strict counterparts. (#40, #41)
 - Property-based and metamorphic tests using
   [metamon](https://github.com/nao1215/metamon) covering
   `multipartkit.encode_form` ↔ `multipartkit.parse` and the

--- a/src/multipartkit.gleam
+++ b/src/multipartkit.gleam
@@ -27,6 +27,10 @@ pub type StreamPart =
 pub type Form =
   form.Form
 
+/// Re-export of `multipartkit/form.FormError`.
+pub type FormError =
+  form.FormError
+
 /// Re-export of `multipartkit/limit.Limits`.
 pub type Limits =
   limit.Limits

--- a/src/multipartkit/form.gleam
+++ b/src/multipartkit/form.gleam
@@ -1,3 +1,4 @@
+import gleam/bool
 import gleam/list
 import gleam/option.{None, Some}
 import multipartkit/infer
@@ -14,6 +15,30 @@ pub opaque type Form {
   Form(reversed_parts: List(Part))
 }
 
+/// Reasons the strict form-builder variants reject input.
+///
+/// The non-strict `add_field` / `add_file` / `add_file_auto` /
+/// `add_file_auto_with` silently strip CR / LF / NUL bytes from
+/// the values that flow into header lines (sealing the #28 header
+/// injection vector). The silent strip is data loss the caller
+/// cannot observe — `add_field("name\n", _)` produces
+/// `name=""`, and `add_file(_, "fi\nle.png", _, _)` concatenates
+/// the two halves into a different valid filename. The `*_strict`
+/// variants surface this as a typed error so callers can render
+/// "field name `foo\\nbar` contains forbidden control bytes"
+/// rather than silently producing the wrong wire. (#40, #41)
+pub type FormError {
+  /// `add_field_strict` saw CR / LF / NUL bytes in the field name.
+  /// Carries the original (un-sanitized) value.
+  NameContainsControlBytes(value: String)
+  /// `add_file_strict` saw CR / LF / NUL bytes in the file's
+  /// filename. Carries the original (un-sanitized) value.
+  FilenameContainsControlBytes(value: String)
+  /// `add_file_strict` saw CR / LF / NUL bytes in the file's
+  /// content type. Carries the original (un-sanitized) value.
+  ContentTypeContainsControlBytes(value: String)
+}
+
 /// A new empty form.
 pub fn new() -> Form {
   Form(reversed_parts: [])
@@ -25,8 +50,13 @@ pub fn new() -> Form {
 /// Carriage returns, line feeds, and NUL bytes in `name` are silently
 /// stripped to prevent header injection. The cached `name` on the resulting
 /// `Part` reflects the sanitized value, matching what a parse-after-encode
-/// round-trip would produce. Use `unsafe_add_part` if byte-exact
-/// preservation is required.
+/// round-trip would produce. The strip is data loss the caller cannot
+/// observe — `add_field("name\n", _)` produces a part with `name=""` —
+/// so callers passing user-typed or upstream data into `name` should
+/// prefer `add_field_strict`, which surfaces the bad input as
+/// `Error(NameContainsControlBytes(value:))` instead. Use
+/// `unsafe_add_part` if byte-exact preservation of arbitrary header
+/// values is required.
 pub fn add_field(form: Form, name: String, value: String) -> Form {
   let safe_name = disposition.sanitize_value(name)
   let header = #(
@@ -49,8 +79,16 @@ pub fn add_field(form: Form, name: String, value: String) -> Form {
 /// Carriage returns, line feeds, and NUL bytes in `name`, `filename`, and
 /// `content_type` are silently stripped to prevent header injection. The
 /// cached `name`, `filename`, and `content_type` on the resulting `Part`
-/// reflect the sanitized values. Use `unsafe_add_part` if byte-exact
-/// preservation is required.
+/// reflect the sanitized values. The strip on `filename` is especially
+/// dangerous — `add_file(_, "fi\nle.png", _, _)` concatenates the two
+/// halves into the *different valid filename* `"file.png"`, which can
+/// change authorisation-relevant identifiers. Callers passing user-typed
+/// or upstream data should prefer `add_file_strict`, which surfaces the
+/// bad input as `Error(NameContainsControlBytes(value:))` /
+/// `Error(FilenameContainsControlBytes(value:))` /
+/// `Error(ContentTypeContainsControlBytes(value:))`. Use
+/// `unsafe_add_part` if byte-exact preservation of arbitrary header
+/// values is required.
 pub fn add_file(
   form: Form,
   name: String,
@@ -103,6 +141,61 @@ pub fn add_file_auto_with(
       }
   }
   add_file(form, name, filename, content_type, body)
+}
+
+/// Strict counterpart of `add_field`: rejects names containing CR /
+/// LF / NUL bytes with `Error(NameContainsControlBytes(value:))`.
+///
+/// The non-strict `add_field` silently strips these bytes (so
+/// `add_field("name\n", _)` produces a part with `name=""`). For
+/// callers that pass user-typed or upstream data into `name` and
+/// want to surface bad inputs as a typed error rather than silent
+/// data loss, use this variant. The `value` payload carries the
+/// caller's original input so the error renders as
+/// "field name `foo\\nbar` contains forbidden control bytes". (#40)
+pub fn add_field_strict(
+  form: Form,
+  name: String,
+  value: String,
+) -> Result(Form, FormError) {
+  use <- bool.guard(
+    when: disposition.has_header_breaking_bytes(name),
+    return: Error(NameContainsControlBytes(value: name)),
+  )
+  Ok(add_field(form, name, value))
+}
+
+/// Strict counterpart of `add_file`: rejects names, filenames, and
+/// content types containing CR / LF / NUL bytes with the matching
+/// `FormError` variant.
+///
+/// The non-strict `add_file` silently strips these bytes. For
+/// `name` the strip leaves an empty string (loud round-trip
+/// failure); for `filename` it concatenates the two halves into a
+/// *different valid filename*, which can change
+/// authorisation-relevant identifiers (the attacker shape
+/// described in #41). The strict variant catches both at the
+/// builder boundary so the wrong wire never gets produced. (#41)
+pub fn add_file_strict(
+  form: Form,
+  name: String,
+  filename: String,
+  content_type: String,
+  body: BitArray,
+) -> Result(Form, FormError) {
+  use <- bool.guard(
+    when: disposition.has_header_breaking_bytes(name),
+    return: Error(NameContainsControlBytes(value: name)),
+  )
+  use <- bool.guard(
+    when: disposition.has_header_breaking_bytes(filename),
+    return: Error(FilenameContainsControlBytes(value: filename)),
+  )
+  use <- bool.guard(
+    when: disposition.has_header_breaking_bytes(content_type),
+    return: Error(ContentTypeContainsControlBytes(value: content_type)),
+  )
+  Ok(add_file(form, name, filename, content_type, body))
 }
 
 /// Append a pre-built `Part` without validation or normalisation.

--- a/test/multipartkit/form_test.gleam
+++ b/test/multipartkit/form_test.gleam
@@ -223,3 +223,97 @@ pub fn add_field_with_quote_in_value_round_trips_test() {
   let assert Ok([p]) = parser.parse(body, content_type)
   part.body(p) |> should.equal(<<"value with \" quote":utf8>>)
 }
+
+// ---------- add_field_strict / add_file_strict (#40 / #41) ----------
+
+pub fn add_field_strict_accepts_safe_name_test() {
+  let assert Ok(f) = form.new() |> form.add_field_strict("name", "value")
+  let assert [p] = form.parts(f)
+  part.name(p) |> should.equal(Some("name"))
+  part.body(p) |> should.equal(<<"value":utf8>>)
+}
+
+pub fn add_field_strict_rejects_lf_in_name_test() {
+  form.new()
+  |> form.add_field_strict("bad\nname", "value")
+  |> should.equal(Error(form.NameContainsControlBytes(value: "bad\nname")))
+}
+
+pub fn add_field_strict_rejects_cr_in_name_test() {
+  form.new()
+  |> form.add_field_strict("bad\rname", "value")
+  |> should.equal(Error(form.NameContainsControlBytes(value: "bad\rname")))
+}
+
+pub fn add_field_strict_rejects_crlf_in_name_test() {
+  form.new()
+  |> form.add_field_strict("bad\r\nname", "value")
+  |> should.equal(Error(form.NameContainsControlBytes(value: "bad\r\nname")))
+}
+
+pub fn add_field_strict_rejects_nul_in_name_test() {
+  form.new()
+  |> form.add_field_strict("bad\u{0}name", "value")
+  |> should.equal(Error(form.NameContainsControlBytes(value: "bad\u{0}name")))
+}
+
+pub fn add_field_strict_value_is_not_validated_test() {
+  // The value goes into the part body, not a header line, so it is
+  // unconstrained — only the `name` is validated for header-breaking
+  // bytes.
+  let assert Ok(f) =
+    form.new() |> form.add_field_strict("ok", "value\nwith\nnewlines")
+  let assert [p] = form.parts(f)
+  part.body(p) |> should.equal(<<"value\nwith\nnewlines":utf8>>)
+}
+
+pub fn add_file_strict_accepts_safe_inputs_test() {
+  let assert Ok(f) =
+    form.new()
+    |> form.add_file_strict("u", "file.png", "image/png", <<137, 80, 78, 71>>)
+  let assert [p] = form.parts(f)
+  part.name(p) |> should.equal(Some("u"))
+  part.filename(p) |> should.equal(Some("file.png"))
+  part.content_type(p) |> should.equal(Some("image/png"))
+  part.body(p) |> should.equal(<<137, 80, 78, 71>>)
+}
+
+pub fn add_file_strict_rejects_lf_in_filename_test() {
+  // The repro from #41: `fi\nle.png` would silently become `file.png`
+  // under `add_file`. The strict variant must surface this as an
+  // explicit error.
+  form.new()
+  |> form.add_file_strict("u", "fi\nle.png", "image/png", <<>>)
+  |> should.equal(Error(form.FilenameContainsControlBytes(value: "fi\nle.png")))
+}
+
+pub fn add_file_strict_rejects_crlf_in_filename_test() {
+  form.new()
+  |> form.add_file_strict("u", "fi\r\nle.png", "image/png", <<>>)
+  |> should.equal(
+    Error(form.FilenameContainsControlBytes(value: "fi\r\nle.png")),
+  )
+}
+
+pub fn add_file_strict_rejects_lf_in_name_test() {
+  form.new()
+  |> form.add_file_strict("u\nname", "file.png", "image/png", <<>>)
+  |> should.equal(Error(form.NameContainsControlBytes(value: "u\nname")))
+}
+
+pub fn add_file_strict_rejects_lf_in_content_type_test() {
+  form.new()
+  |> form.add_file_strict("u", "file.png", "image/png\nX-Evil: 1", <<>>)
+  |> should.equal(
+    Error(form.ContentTypeContainsControlBytes(value: "image/png\nX-Evil: 1")),
+  )
+}
+
+pub fn add_file_strict_first_failure_wins_test() {
+  // When all three inputs are bad, the error variant matches the
+  // first checked field (name). Pinning the order so callers can rely
+  // on it for rendering.
+  form.new()
+  |> form.add_file_strict("u\n", "f\n", "t\n", <<>>)
+  |> should.equal(Error(form.NameContainsControlBytes(value: "u\n")))
+}


### PR DESCRIPTION
## Summary

The existing `form.add_field` / `form.add_file` /
`form.add_file_auto[_with]` silently strip CR / LF / NUL bytes from
the values that flow into header lines. The strip seals the #28
header-injection vector but introduces silent data loss the caller
cannot observe:

- `add_field(\"name\\n\", _)` produces a part with `name=\"\"`. A
  round-trip lookup by the original name silently fails (#40).
- `add_file(_, \"fi\\nle.png\", _, _)` concatenates the two halves
  into the *different valid filename* `\"file.png\"`. An attacker
  can craft `rep\\nort_admin.csv` to target a privileged filename
  after stripping (#41).

Add typed-error counterparts that surface the bad input rather than
coercing it.

## Changes

### `src/multipartkit/form.gleam`

- New `FormError` type with three variants:
  `NameContainsControlBytes(value:)`,
  `FilenameContainsControlBytes(value:)`,
  `ContentTypeContainsControlBytes(value:)`. Each carries the
  original (un-sanitized) input so the error renders as
  \"field name `foo\\\\nbar` contains forbidden control bytes\".
- `add_field_strict(form, name, value) -> Result(Form, FormError)`
  rejects names with header-breaking bytes; otherwise calls the
  existing `add_field`.
- `add_file_strict(form, name, filename, content_type, body) ->
  Result(Form, FormError)` rejects any of the three header-bound
  inputs. Variants are checked in registration order
  (name, filename, content type) so callers can rely on the
  first-failure shape.
- Both reuse the existing
  `disposition.has_header_breaking_bytes` helper so strict /
  non-strict share one source of truth.
- Update the `add_field` / `add_file` doc-comments to warn about
  the silent strip and point at the strict counterparts.

### `src/multipartkit.gleam`

- Re-export `FormError` so callers can pattern-match on the typed
  error without reaching into `multipartkit/form` directly.

### `test/multipartkit/form_test.gleam`

- Eleven new \`add_field_strict\` / \`add_file_strict\` tests covering:
  safe inputs (returns `Ok(Form)`), LF / CR / CRLF / NUL in field
  name, the same characters in filename, content type, and
  `add_file_strict` name. The field `value` going to the body is
  unconstrained — only the `name` is validated for header-breaking
  bytes. First-failure-wins ordering when all three file inputs
  are bad.

### `CHANGELOG.md`

- Added entry under `[Unreleased]`.

## Design Decisions

**Why two strict variants rather than swapping the existing
functions to `Result`.** Swapping is breaking — every existing
caller would need to thread `let assert Ok(_) = ...` through their
form builder. The strict-variant pattern is non-breaking and
matches the shape adopted in `dataprep` (`parse.float` /
`parse.float_strict`).

**Why three variants of `FormError` and not one
`HeaderInjectionAttempt(field:, value:)`.** Pattern-matching on
specific variants reads better at the call site than threading a
field name through:

```gleam
case form.add_file_strict(form, name, filename, ct, body) {
  Ok(form) -> ...
  Error(form.NameContainsControlBytes(value:)) -> reject_name(value)
  Error(form.FilenameContainsControlBytes(value:)) -> reject_filename(value)
  Error(form.ContentTypeContainsControlBytes(value:)) -> reject_ct(value)
}
```

The variants also future-proof the type for other validation we
might add (token grammar, length limits, etc.) without churning
the existing variants.

**Why first-failure-wins rather than collecting all errors.**
\"Reject this part because of bad input\" is the contract; the
caller fixes one input at a time. Collecting errors is the shape
`dataprep/validated.map2` provides for independent fields, but
header values for a single part are coupled.

## Test plan

- [x] `gleam test` — 225 passed (was 213; +12 new tests including
      one repro from the issue body in #41:
      `add_file_strict(_, _, \"fi\\\\nle.png\", _, _)` is rejected)
- [x] `just check` — format-check + glinter + check + build + test
- [x] No metamon properties had to change
- [x] Existing `add_field` / `add_file` callers see no breaking
      change

Closes #40. Closes #41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict form-building functions that validate field names, filenames, and content types, rejecting invalid input with specific error messages instead of silently modifying data.
  * Introduced `FormError` type for detailed validation error reporting.
  * Updated documentation of existing form functions to clarify their data sanitization behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/multipartkit/pull/44)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->