### PR TITLE
docs(readme): add Security notes section for filenames and header bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- README gains a `## Security notes` section with two callouts:
+  (a) `part.filename` returns the client-supplied filename
+  unsanitised, and naive `simplifile.write("./uploads/" <> filename,
+  bytes)` is exposed to path traversal — the section shows a
+  basename-style sanitiser and the strongly-preferred content-hash
+  alternative; (b) the form-builder strip behaviour and the
+  strict-variant escape hatch (cross-references the
+  `add_field_strict` / `add_file_strict` entry below). Comparable
+  Node / Go libraries (busboy, gorilla/mux multipart) explicitly
+  warn; this brings multipartkit in line. (#42)
+
 ### Added
 
 - **`multipartkit/form`**: `add_field_strict` and `add_file_strict`

--- a/README.md
+++ b/README.md
@@ -87,6 +87,65 @@ gleam run
 
 Run them all from the repo root with `just examples`.
 
+## Security notes
+
+### Filenames are user-controlled
+
+`part.filename(part)` returns the byte sequence the client sent,
+**unsanitised** — including path-traversal sequences (`../`,
+absolute paths like `/etc/passwd`, Windows UNC like `\\server\share`,
+URL-encoded variants like `..%2f..%2fetc%2fpasswd`). Sanitising the
+filename is the consumer's responsibility; multipartkit deliberately
+does not mutate it because the byte-exact original is sometimes the
+right value to keep (e.g. when the client supplies a content-derived
+identifier).
+
+A naive consumer that joins the filename to a server-side path is
+exposed to path traversal:
+
+```gleam
+let assert Ok(part) = mquery.required_file(parts, "upload")
+let bytes = part.body(part)
+let assert Some(filename) = part.filename(part)
+simplifile.write("./uploads/" <> filename, bytes)
+// ^^^^ attacker-controlled, writes outside ./uploads
+```
+
+Sanitise before joining, or — strongly preferred — derive the
+server-side path from a content hash so the user-supplied name is
+never on the filesystem:
+
+```gleam
+import filepath
+import gleam/string
+
+let safe = filepath.base_name(filename) |> string.replace("..", "")
+simplifile.write(filepath.join("./uploads", safe), bytes)
+```
+
+```gleam
+// Even better: use a content-derived id and recover the extension
+// from a magic-byte detector instead of the user-supplied filename.
+let extension = case mimetype.essence_of(detected) {
+  "image/png" -> "png"
+  "image/jpeg" -> "jpg"
+  _ -> "bin"
+}
+let server_path = filepath.join("./uploads", sha256_of(bytes) <> "." <> extension)
+```
+
+### Header-breaking bytes in form-builder values
+
+`form.add_field` / `form.add_file` / `form.add_file_auto[_with]`
+silently strip CR / LF / NUL bytes from values that flow into header
+lines. The strip seals the CRLF-injection vector but loses the
+caller's input — `add_file(_, "fi\nle.png", _, _)` produces a part
+with filename `"file.png"`, a *different valid filename*. For
+callers passing user-typed or upstream data, prefer
+`form.add_field_strict` / `form.add_file_strict`, which return
+`Result(Form, FormError)` and surface the bad input as a typed
+error instead of coercing it.
+
 ## Streaming semantics
 
 The streaming parser is opt-in. Add it to your project only when you


### PR DESCRIPTION
## Summary

The README leads consumers through a \"build a Form, parse a request,
read `part.filename` / `part.body`\" pipeline that naturally implies
an HTTP upload endpoint. Two security-relevant gaps were
undocumented:

1. `part.filename` returns the byte sequence the client sent
   **unsanitised** — including path-traversal sequences (`../`,
   absolute paths, Windows UNC, URL-encoded variants). A naive
   consumer that joins it to a server-side path is exposed to
   path traversal. multipartkit deliberately preserves the
   byte-exact original; the README needed to flag that the
   *consumer* must sanitise.
2. The form-builder strip behaviour (`add_field` / `add_file`
   silently strip CR / LF / NUL) wasn't surfaced anywhere
   prominent. Consumers building forms from upstream data need to
   know about the strict-variant escape hatch.

## Changes

### `README.md`

- New `## Security notes` section between `## Examples` and
  `## Streaming semantics`.
- Subsection \"Filenames are user-controlled\":
  - Lists the unsafe shapes the byte sequence may carry (`../`,
    absolute paths, UNC, URL-encoded variants).
  - Repro of the naive `simplifile.write(\"./uploads/\" <> filename,
    bytes)` pattern as a counter-example.
  - Two recommended approaches:
    1. Basename + \"..\"-strip sanitiser as the minimum defence.
    2. Content-hash filename derived from the bytes (using
       `mimetype.essence_of` for the extension) — the strongly
       preferred path because the user-supplied name is never on
       the filesystem.
- Subsection \"Header-breaking bytes in form-builder values\":
  - Names the strip behaviour and the
    `add_field(_, \"fi\\\\nle.png\", _, _)` →
    `\"file.png\"` data-loss case from #41.
  - Cross-references `add_field_strict` / `add_file_strict` (added
    in the previous PR for #40 / #41) as the typed-error
    alternative.

### `CHANGELOG.md`

- Documentation entry under `[Unreleased]`.

## Design Decisions

**Why a separate `## Security notes` section rather than warnings
inline in the Quick start.** A single dedicated section is easier to
link to from PR reviews / Slack / docs (\"see Security notes for
filename sanitisation\") and groups related guidance together. The
Quick start stays focused on \"how do I use the API\".

**Why two sanitiser examples instead of one.** The basename-strip
example matches what consumers reach for first; the content-hash
example is what they should actually use for any user-uploaded
content. Showing both, with the second labelled \"even better\",
nudges without forcing.

**Why no built-in `safe_filename` helper.** Sanitisation policy is
application-specific (allowed characters, max length, namespace
collision, ...). multipartkit shouldn't pick a default. The README
shows the building blocks (`filepath.base_name`, `string.replace`,
content-derived hashes) without committing the library to a
sanitiser API.

## Test plan

- [x] `just check` — format-check + glinter + check + build + test
- [x] No code change; README only
- [x] README quick-start snippet check still passes (the new
      section is between unrelated subsections)

Closes #42.