### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-09
+
 ### Documentation
 
 - README gains a `## Security notes` section with two callouts:

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.10.0"
+version = "0.11.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Documentation

- README gains a `## Security notes` section with two callouts:
  (a) `part.filename` returns the client-supplied filename
  unsanitised, and naive `simplifile.write("./uploads/" <> filename,
  bytes)` is exposed to path traversal — the section shows a
  basename-style sanitiser and the strongly-preferred content-hash
  alternative; (b) the form-builder strip behaviour and the
  strict-variant escape hatch (cross-references the
  `add_field_strict` / `add_file_strict` entry below). Comparable
  Node / Go libraries (busboy, gorilla/mux multipart) explicitly
  warn; this brings multipartkit in line. (#42)

### Added

- **`multipartkit/form`**: `add_field_strict` and `add_file_strict`
  are the typed-error counterparts of the existing
  `add_field` / `add_file`. The non-strict variants silently strip
  CR / LF / NUL bytes from the values that flow into header lines
  (so `add_field("name\n", _)` produces a part with `name=""`,
  and `add_file(_, "fi\nle.png", _, _)` concatenates the two
  halves into the *different valid filename* `"file.png"` — the
  authorisation-relevant identifier change described in #41).
  The strict variants surface the bad input as
  `Error(NameContainsControlBytes(value:))` /
  `Error(FilenameContainsControlBytes(value:))` /
  `Error(ContentTypeContainsControlBytes(value:))` so callers
  passing user-typed or upstream data can render an actionable
  error rather than producing the wrong wire silently. Add the
  matching `FormError` type (re-exported from the top-level
  `multipartkit` module). The existing non-strict variants keep
  their void return for backward compatibility, with doc-comments
  updated to point at the strict counterparts. (#40, #41)
- Property-based and metamorphic tests using
  [metamon](https://github.com/nao1215/metamon) covering
  `multipartkit.encode_form` ↔ `multipartkit.parse` and the
  `multipartkit/form` builder. Lives in
  `test/multipartkit_metamon_test.gleam`. Highlights: the
  encode-then-parse round-trip preserves field count, name, and
  value for safe (alphanumeric) inputs; `query.field` and
  `query.fields` agree on the registration order for duplicate
  names; file parts round-trip name / filename / content-type /
  body byte-exact; `add_field` body equals `<<value:utf8>>`;
  `add_file` preserves byte-exact body of arbitrary `BitArray`;
  CR / LF / NUL injection in `name` / `filename` is silently
  stripped (pinning the existing #28-fix sanitization until #40 /
  #41 switch this to a typed error); empty form parses to the
  empty part list. The round-trip generators use `no_edges` so the
  CR / LF strip behaviour is exercised explicitly rather than as a
  silent edge.
