### PR TITLE
refactor(form): add labelled arguments to add_field and add_file variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `multipartkit/form.add_field`, `add_file`, `add_field_strict`, and
+  `add_file_strict` now have labelled arguments (`name:`, `value:`,
+  `filename:`, `content_type:`, `body:`) so builder chains read like
+  the rest of the Gleam ecosystem. Source-compatible: existing
+  positional callers continue to work unchanged. (#47)
+
 ## [0.11.0] - 2026-05-09
 
 ### Documentation

--- a/src/multipartkit/form.gleam
+++ b/src/multipartkit/form.gleam
@@ -57,7 +57,7 @@ pub fn new() -> Form {
 /// `Error(NameContainsControlBytes(value:))` instead. Use
 /// `unsafe_add_part` if byte-exact preservation of arbitrary header
 /// values is required.
-pub fn add_field(form: Form, name: String, value: String) -> Form {
+pub fn add_field(form: Form, name name: String, value value: String) -> Form {
   let safe_name = disposition.sanitize_value(name)
   let header = #(
     "Content-Disposition",
@@ -91,10 +91,10 @@ pub fn add_field(form: Form, name: String, value: String) -> Form {
 /// values is required.
 pub fn add_file(
   form: Form,
-  name: String,
-  filename: String,
-  content_type: String,
-  body: BitArray,
+  name name: String,
+  filename filename: String,
+  content_type content_type: String,
+  body body: BitArray,
 ) -> Form {
   push(form, build_file_part(name, filename, content_type, body))
 }
@@ -140,7 +140,7 @@ pub fn add_file_auto_with(
         None -> "application/octet-stream"
       }
   }
-  add_file(form, name, filename, content_type, body)
+  add_file(form, name:, filename:, content_type:, body:)
 }
 
 /// Strict counterpart of `add_field`: rejects names containing CR /
@@ -155,14 +155,14 @@ pub fn add_file_auto_with(
 /// "field name `foo\\nbar` contains forbidden control bytes". (#40)
 pub fn add_field_strict(
   form: Form,
-  name: String,
-  value: String,
+  name name: String,
+  value value: String,
 ) -> Result(Form, FormError) {
   use <- bool.guard(
     when: disposition.has_header_breaking_bytes(name),
     return: Error(NameContainsControlBytes(value: name)),
   )
-  Ok(add_field(form, name, value))
+  Ok(add_field(form, name:, value:))
 }
 
 /// Strict counterpart of `add_file`: rejects names, filenames, and
@@ -178,10 +178,10 @@ pub fn add_field_strict(
 /// builder boundary so the wrong wire never gets produced. (#41)
 pub fn add_file_strict(
   form: Form,
-  name: String,
-  filename: String,
-  content_type: String,
-  body: BitArray,
+  name name: String,
+  filename filename: String,
+  content_type content_type: String,
+  body body: BitArray,
 ) -> Result(Form, FormError) {
   use <- bool.guard(
     when: disposition.has_header_breaking_bytes(name),
@@ -195,7 +195,7 @@ pub fn add_file_strict(
     when: disposition.has_header_breaking_bytes(content_type),
     return: Error(ContentTypeContainsControlBytes(value: content_type)),
   )
-  Ok(add_file(form, name, filename, content_type, body))
+  Ok(add_file(form, name:, filename:, content_type:, body:))
 }
 
 /// Append a pre-built `Part` without validation or normalisation.

--- a/test/multipartkit/form_test.gleam
+++ b/test/multipartkit/form_test.gleam
@@ -317,3 +317,66 @@ pub fn add_file_strict_first_failure_wins_test() {
   |> form.add_file_strict("u\n", "f\n", "t\n", <<>>)
   |> should.equal(Error(form.NameContainsControlBytes(value: "u\n")))
 }
+
+// ---------- labelled-argument call sites (#47) ----------
+//
+// The builder functions accept labelled arguments alongside the
+// positional form. These tests pin the labelled call shape so the
+// labels stay part of the public API (a label rename is a breaking
+// change).
+
+pub fn add_field_accepts_labelled_arguments_test() {
+  let f =
+    form.new()
+    |> form.add_field(name: "a", value: "1")
+    |> form.add_field(name: "b", value: "2")
+  let parts = form.parts(f)
+  case parts {
+    [first, second] -> {
+      part.name(first) |> should.equal(Some("a"))
+      part.body(first) |> should.equal(<<"1":utf8>>)
+      part.name(second) |> should.equal(Some("b"))
+      part.body(second) |> should.equal(<<"2":utf8>>)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn add_file_accepts_labelled_arguments_test() {
+  let f =
+    form.new()
+    |> form.add_file(
+      name: "upload",
+      filename: "doc.pdf",
+      content_type: "application/pdf",
+      body: <<"%PDF":utf8>>,
+    )
+  let assert [the_part] = form.parts(f)
+  part.name(the_part) |> should.equal(Some("upload"))
+  part.filename(the_part) |> should.equal(Some("doc.pdf"))
+  part.content_type(the_part) |> should.equal(Some("application/pdf"))
+  part.body(the_part) |> should.equal(<<"%PDF":utf8>>)
+}
+
+pub fn add_field_strict_accepts_labelled_arguments_test() {
+  let assert Ok(f) = form.new() |> form.add_field_strict(name: "k", value: "v")
+  let assert [p] = form.parts(f)
+  part.name(p) |> should.equal(Some("k"))
+  part.body(p) |> should.equal(<<"v":utf8>>)
+}
+
+pub fn add_file_strict_accepts_labelled_arguments_test() {
+  let assert Ok(f) =
+    form.new()
+    |> form.add_file_strict(
+      name: "u",
+      filename: "file.png",
+      content_type: "image/png",
+      body: <<137, 80, 78, 71>>,
+    )
+  let assert [p] = form.parts(f)
+  part.name(p) |> should.equal(Some("u"))
+  part.filename(p) |> should.equal(Some("file.png"))
+  part.content_type(p) |> should.equal(Some("image/png"))
+  part.body(p) |> should.equal(<<137, 80, 78, 71>>)
+}


### PR DESCRIPTION
## Summary

`multipartkit/form` is a builder API meant to chain via `|>`, but its mutators (`add_field`, `add_file`, and the `_strict` variants) took only positional arguments. That breaks the readability pattern most Gleam-ecosystem builders adopt (`automata.new(initial_state:, ...)`, `sqlode.raw_query_for_test(name:, sql:, ...)`). This PR adds labelled arguments while keeping the receiver positional so pipe chains still read naturally.

## Changes

- `src/multipartkit/form.gleam` — `add_field`, `add_file`, `add_field_strict`, `add_file_strict` now have labelled parameters (`name:`, `value:`, `filename:`, `content_type:`, `body:`). Internal call sites (the `Ok(add_field(...))` chains in the `_strict` variants and `add_file_auto_with`) updated to use the same labels so glinter's `missing_labels` rule stays happy.
- `test/multipartkit/form_test.gleam` — 4 new tests exercising the labelled call shape for each of the four mutators, in addition to the existing positional-form tests.
- `CHANGELOG.md` — `## [Unreleased]` `### Changed` entry.

## Design Decisions

- **Source-compatible.** Gleam's labelled-args feature is purely additive at the call site — existing positional callers (`form.add_field(form, \"name\", \"value\")`) keep working unchanged. Verified by the unchanged-and-passing existing test suite.
- **First argument stays unlabelled.** `form: Form` carries no label so `|>` chains read as `form |> form.add_field(name: ..., value: ...)`.
- **Examples not touched.** `just check-readme` enforces byte-equality between README and `examples/quick_start`, so updating the example would require a matching README change. That's a separate ergonomics PR; this one stays scoped to the function signatures.

## Testing

- `mise exec -- just ci` — pass (deps + format-check + check + lint + build + test on JS + examples).
- `mise exec -- gleam test --target erlang` — 229 passed.
- `mise exec -- gleam test --target javascript` — 229 passed.
- All four examples (quick_start / parse_request / streaming_parse / mimetype_inference) build and run.

## Limitations

None — this is a strictly additive API change.

Closes #47