### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-11
+
 ### Changed
 
 - `multipartkit/form.add_field`, `add_file`, `add_field_strict`, and

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.11.0"
+version = "0.12.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Changed

- `multipartkit/form.add_field`, `add_file`, `add_field_strict`, and
  `add_file_strict` now have labelled arguments (`name:`, `value:`,
  `filename:`, `content_type:`, `body:`) so builder chains read like
  the rest of the Gleam ecosystem. Source-compatible: existing
  positional callers continue to work unchanged. (#47)
