### PR TITLE
feat(form): reject empty field name in add_field_strict and add_file_strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `multipartkit/form.add_field_strict` and `add_file_strict` now reject empty or whitespace-only `name` with the new `Error(EmptyFieldName(value:))` variant, aligning with RFC 7578 §4.2 which requires the `Content-Disposition` `name` parameter to be the field name; the non-strict `add_field` / `add_file` keep their existing silent-accept behaviour for backward compatibility. (#51)
+
 ### Changed
 
 - `multipartkit/content_disposition.parse` now enforces RFC 7230 §3.2.6 `quoted-pair` strictly: a `\X` whose `X` is outside `HTAB / SP / VCHAR / obs-text` (for example `NUL`, `CR`, `LF`, or any other ASCII control byte) is rejected with the new `Error(InvalidQuotedPair(_))` instead of silently dropping the backslash, blocking `NUL`-smuggling into the decoded `name` / `filename`. (#50)

--- a/src/multipartkit/form.gleam
+++ b/src/multipartkit/form.gleam
@@ -1,6 +1,7 @@
 import gleam/bool
 import gleam/list
 import gleam/option.{None, Some}
+import gleam/string
 import multipartkit/infer
 import multipartkit/internal/disposition
 import multipartkit/part.{type Part}
@@ -37,6 +38,15 @@ pub type FormError {
   /// `add_file_strict` saw CR / LF / NUL bytes in the file's
   /// content type. Carries the original (un-sanitized) value.
   ContentTypeContainsControlBytes(value: String)
+  /// `add_field_strict` / `add_file_strict` saw an empty (or
+  /// whitespace-only) field name. RFC 7578 §4.2 requires the
+  /// `Content-Disposition` `name` parameter to be the field name,
+  /// and an empty name produces a wire image whose interpretation
+  /// is implementation-defined at the receiver (some servers skip
+  /// the field, some overwrite siblings keyed on `""`, some reject
+  /// the whole body). Carries the original (un-trimmed) value so
+  /// callers can render diagnostics. (#51)
+  EmptyFieldName(value: String)
 }
 
 /// A new empty form.
@@ -47,16 +57,20 @@ pub fn new() -> Form {
 /// Append a text field. `value` is encoded as UTF-8 in the part body. No
 /// filename is set.
 ///
-/// Carriage returns, line feeds, and NUL bytes in `name` are silently
-/// stripped to prevent header injection. The cached `name` on the resulting
-/// `Part` reflects the sanitized value, matching what a parse-after-encode
-/// round-trip would produce. The strip is data loss the caller cannot
-/// observe — `add_field("name\n", _)` produces a part with `name=""` —
-/// so callers passing user-typed or upstream data into `name` should
-/// prefer `add_field_strict`, which surfaces the bad input as
-/// `Error(NameContainsControlBytes(value:))` instead. Use
-/// `unsafe_add_part` if byte-exact preservation of arbitrary header
-/// values is required.
+/// RFC 7578 §4.2 requires the `Content-Disposition` `name` parameter
+/// to be non-empty (it is the field name itself). This non-strict
+/// variant does **not** enforce that — it silently accepts `""` and
+/// also silently strips CR / LF / NUL bytes from `name` to prevent
+/// header injection. The cached `name` on the resulting `Part`
+/// reflects the sanitized value, matching what a parse-after-encode
+/// round-trip would produce. The silent acceptance and strip is data
+/// loss the caller cannot observe — `add_field("", _)` produces
+/// `name=""`, and `add_field("name\n", _)` produces a part with
+/// `name=""` — so callers passing user-typed or upstream data into
+/// `name` should prefer `add_field_strict`, which surfaces both
+/// failure modes as typed errors (`EmptyFieldName(value:)` and
+/// `NameContainsControlBytes(value:)`). Use `unsafe_add_part` if
+/// byte-exact preservation of arbitrary header values is required.
 pub fn add_field(form: Form, name name: String, value value: String) -> Form {
   let safe_name = disposition.sanitize_value(name)
   let header = #(
@@ -76,15 +90,21 @@ pub fn add_field(form: Form, name name: String, value value: String) -> Form {
 
 /// Append a file part with an explicit content type.
 ///
-/// Carriage returns, line feeds, and NUL bytes in `name`, `filename`, and
-/// `content_type` are silently stripped to prevent header injection. The
-/// cached `name`, `filename`, and `content_type` on the resulting `Part`
-/// reflect the sanitized values. The strip on `filename` is especially
-/// dangerous — `add_file(_, "fi\nle.png", _, _)` concatenates the two
-/// halves into the *different valid filename* `"file.png"`, which can
-/// change authorisation-relevant identifiers. Callers passing user-typed
-/// or upstream data should prefer `add_file_strict`, which surfaces the
-/// bad input as `Error(NameContainsControlBytes(value:))` /
+/// RFC 7578 §4.2 requires the `Content-Disposition` `name` parameter
+/// to be non-empty (the `filename` parameter may legitimately be
+/// empty). This non-strict variant does **not** enforce the
+/// non-empty `name` rule — it silently accepts `""` and also
+/// silently strips CR / LF / NUL bytes from `name`, `filename`, and
+/// `content_type` to prevent header injection. The cached `name`,
+/// `filename`, and `content_type` on the resulting `Part` reflect
+/// the sanitized values. The strip on `filename` is especially
+/// dangerous — `add_file(_, "fi\nle.png", _, _)` concatenates the
+/// two halves into the *different valid filename* `"file.png"`,
+/// which can change authorisation-relevant identifiers. Callers
+/// passing user-typed or upstream data should prefer
+/// `add_file_strict`, which surfaces the bad input as
+/// `Error(EmptyFieldName(value:))` /
+/// `Error(NameContainsControlBytes(value:))` /
 /// `Error(FilenameContainsControlBytes(value:))` /
 /// `Error(ContentTypeContainsControlBytes(value:))`. Use
 /// `unsafe_add_part` if byte-exact preservation of arbitrary header
@@ -144,20 +164,31 @@ pub fn add_file_auto_with(
 }
 
 /// Strict counterpart of `add_field`: rejects names containing CR /
-/// LF / NUL bytes with `Error(NameContainsControlBytes(value:))`.
+/// LF / NUL bytes with `Error(NameContainsControlBytes(value:))`,
+/// and rejects empty or whitespace-only names with
+/// `Error(EmptyFieldName(value:))`.
 ///
-/// The non-strict `add_field` silently strips these bytes (so
-/// `add_field("name\n", _)` produces a part with `name=""`). For
+/// The non-strict `add_field` silently strips control bytes (so
+/// `add_field("name\n", _)` produces a part with `name=""`), and
+/// also silently accepts a truly empty `name`. RFC 7578 §4.2
+/// requires the `Content-Disposition` `name` parameter to be the
+/// field name; an empty name produces a wire image whose
+/// interpretation is implementation-defined at the receiver. For
 /// callers that pass user-typed or upstream data into `name` and
 /// want to surface bad inputs as a typed error rather than silent
 /// data loss, use this variant. The `value` payload carries the
 /// caller's original input so the error renders as
-/// "field name `foo\\nbar` contains forbidden control bytes". (#40)
+/// "field name `foo\\nbar` contains forbidden control bytes" or
+/// "field name `   ` is empty". (#40, #51)
 pub fn add_field_strict(
   form: Form,
   name name: String,
   value value: String,
 ) -> Result(Form, FormError) {
+  use <- bool.guard(
+    when: string.trim(name) == "",
+    return: Error(EmptyFieldName(value: name)),
+  )
   use <- bool.guard(
     when: disposition.has_header_breaking_bytes(name),
     return: Error(NameContainsControlBytes(value: name)),
@@ -167,15 +198,19 @@ pub fn add_field_strict(
 
 /// Strict counterpart of `add_file`: rejects names, filenames, and
 /// content types containing CR / LF / NUL bytes with the matching
-/// `FormError` variant.
+/// `FormError` variant, and rejects an empty or whitespace-only
+/// `name` with `Error(EmptyFieldName(value:))`. (`filename` may
+/// legitimately be empty — only `name` is required to be
+/// non-empty per RFC 7578 §4.2.)
 ///
-/// The non-strict `add_file` silently strips these bytes. For
+/// The non-strict `add_file` silently strips control bytes. For
 /// `name` the strip leaves an empty string (loud round-trip
 /// failure); for `filename` it concatenates the two halves into a
 /// *different valid filename*, which can change
 /// authorisation-relevant identifiers (the attacker shape
 /// described in #41). The strict variant catches both at the
-/// builder boundary so the wrong wire never gets produced. (#41)
+/// builder boundary so the wrong wire never gets produced.
+/// (#41, #51)
 pub fn add_file_strict(
   form: Form,
   name name: String,
@@ -183,6 +218,10 @@ pub fn add_file_strict(
   content_type content_type: String,
   body body: BitArray,
 ) -> Result(Form, FormError) {
+  use <- bool.guard(
+    when: string.trim(name) == "",
+    return: Error(EmptyFieldName(value: name)),
+  )
   use <- bool.guard(
     when: disposition.has_header_breaking_bytes(name),
     return: Error(NameContainsControlBytes(value: name)),

--- a/test/regression_empty_field_name_test.gleam
+++ b/test/regression_empty_field_name_test.gleam
@@ -1,0 +1,105 @@
+//// Regression tests for Issue #51: `multipartkit/form.add_field_strict`
+//// and `add_file_strict` must reject empty (or whitespace-only) field
+//// names with `Error(EmptyFieldName(value:))`.
+////
+//// RFC 7578 §4.2 says the `Content-Disposition` `name` parameter is the
+//// *field name*, and an empty name produces a wire image whose
+//// interpretation is implementation-defined at the receiver (skip,
+//// overwrite siblings keyed on `""`, or reject the whole body). The
+//// non-strict `add_field` / `add_file` silently accept `""` for
+//// backward compatibility; the strict variants must surface it.
+
+import gleeunit/should
+import multipartkit
+import multipartkit/form
+
+// === add_field_strict: empty name rejected ===
+
+pub fn add_field_strict_empty_name_rejected_test() {
+  case form.add_field_strict(form.new(), "", "value") {
+    Error(form.EmptyFieldName(value: "")) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn add_field_strict_whitespace_only_name_rejected_test() {
+  case form.add_field_strict(form.new(), "   ", "value") {
+    Error(form.EmptyFieldName(value: "   ")) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn add_field_strict_tab_only_name_rejected_test() {
+  case form.add_field_strict(form.new(), "\t\t", "value") {
+    Error(form.EmptyFieldName(value: "\t\t")) -> Nil
+    _ -> should.fail()
+  }
+}
+
+// === add_file_strict: empty name rejected ===
+
+pub fn add_file_strict_empty_name_rejected_test() {
+  case
+    form.add_file_strict(form.new(), "", "file.txt", "text/plain", <<"hi">>)
+  {
+    Error(form.EmptyFieldName(value: "")) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn add_file_strict_whitespace_only_name_rejected_test() {
+  case
+    form.add_file_strict(form.new(), "  ", "file.txt", "text/plain", <<"hi">>)
+  {
+    Error(form.EmptyFieldName(value: "  ")) -> Nil
+    _ -> should.fail()
+  }
+}
+
+// === add_file_strict: empty filename is still allowed ===
+
+pub fn add_file_strict_empty_filename_allowed_test() {
+  // Per RFC 7578 §4.2 only `name` is required; `filename` may be empty.
+  case form.add_file_strict(form.new(), "name", "", "text/plain", <<"hi">>) {
+    Ok(_) -> Nil
+    Error(_) -> should.fail()
+  }
+}
+
+// === Non-empty name still works (regression baseline) ===
+
+pub fn add_field_strict_normal_name_works_test() {
+  case form.add_field_strict(form.new(), "name", "value") {
+    Ok(f) -> {
+      let #(_ct, _body) = multipartkit.encode_form(f)
+      Nil
+    }
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn add_file_strict_normal_name_works_test() {
+  case
+    form.add_file_strict(form.new(), "field", "file.txt", "text/plain", <<
+      "hi",
+    >>)
+  {
+    Ok(f) -> {
+      let #(_ct, _body) = multipartkit.encode_form(f)
+      Nil
+    }
+    Error(_) -> should.fail()
+  }
+}
+
+// === Non-strict add_field still silently accepts (backward compat) ===
+
+pub fn add_field_non_strict_empty_name_still_accepted_test() {
+  // Backward-compatibility pin: the non-strict variant must not gain
+  // a hidden reject in this release.
+  let f = form.add_field(form.new(), "", "value")
+  case form.parts(f) {
+    [_one] -> Nil
+    _ -> should.fail()
+  }
+}


### PR DESCRIPTION
## Summary

`multipartkit/form.add_field_strict` and `add_file_strict` previously accepted an empty (or whitespace-only) `name` silently, producing a wire image with `Content-Disposition: form-data; name=""`. RFC 7578 §4.2 requires the `name` parameter to be the field name itself; an empty value is implementation-defined at the receiver (skip, overwrite siblings keyed on `""`, or reject the body). The strict variants now reject it with the new `Error(EmptyFieldName(value:))` variant on `FormError`, while the non-strict `add_field` / `add_file` keep their existing silent-accept behaviour for backward compatibility.

## Changes

- `src/multipartkit/form.gleam`: add `EmptyFieldName(value:)` variant to `FormError`; `add_field_strict` and `add_file_strict` now `bool.guard` on `string.trim(name) == ""` ahead of the existing CR/LF/NUL check and return `Error(EmptyFieldName(value: name))`; doc-comments on all four builders updated to spell out the RFC 7578 §4.2 non-empty `name` requirement and the strict-variant escape hatch.
- `test/regression_empty_field_name_test.gleam`: new regression suite covering empty / whitespace-only / tab-only `name` rejection for both strict builders, empty `filename` still allowed by `add_file_strict`, non-empty `name` still works, and a backward-compatibility pin that non-strict `add_field("", _)` still silently accepts.
- `CHANGELOG.md`: `## [Unreleased] / ### Added` entry for the new variant and the strict-builder behaviour.

## Design Decisions

Issue #51 listed three approaches (A: strict-Result reject, B: panic, C: docs-only). Approach A on the strict variants only — leaving non-strict behaviour intact — was chosen because the strict variants were introduced for exactly this kind of typed-error surfacing (#40, #41) and the non-strict variants have a documented silent-accept contract that callers may already rely on; a breaking change there would force every existing caller to migrate without a way to opt back into the old shape. The `string.trim(name) == ""` predicate covers both the bare empty string and whitespace-only inputs in a single branch, matching the Issue's acceptance criteria (`"   "` must also reject). The empty-name guard runs before the control-byte guard so that a caller passing `""` sees `EmptyFieldName` rather than the (technically also true) `NameContainsControlBytes` with the same empty payload. `filename` is intentionally left allowed-empty in `add_file_strict` because RFC 7578 §4.2 only constrains `name`.

Closes #51