### PR TITLE
docs(infer): clarify default no-op behaviour of content_type helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- `multipartkit/infer.content_type_from_filename` and `content_type_from_bytes` docstrings, and the README "Pluggable content-type inference" bullet, now state explicitly that these top-level helpers are **default no-ops** of the pluggable inference interface and always return `None`; callers wanting real inference must wire an `Inferer` (e.g. backed by `nao1215/mimetype`) into `form.add_file_auto_with`. (#52)
+
 ### Added
 
 - `multipartkit/form.add_field_strict` and `add_file_strict` now reject empty or whitespace-only `name` with the new `Error(EmptyFieldName(value:))` variant, aligning with RFC 7578 §4.2 which requires the `Content-Disposition` `name` parameter to be the field name; the non-strict `add_field` / `add_file` keep their existing silent-accept behaviour for backward compatibility. (#51)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ target: `multipart/form-data`. Secondary: `multipart/mixed` and
   `filename*` (UTF-8 and ISO-8859-1).
 - Pluggable content-type inference — wire
   [`nao1215/mimetype`](https://github.com/nao1215/mimetype) (or any
-  other inferer) without changing this library.
+  other inferer) without changing this library. The top-level
+  `multipartkit/infer.content_type_from_filename` and
+  `content_type_from_bytes` are documented **default no-ops** that
+  always return `None`; actual inference happens when an `Inferer` is
+  passed to `form.add_file_auto_with` (see
+  [`examples/mimetype_inference`](examples/mimetype_inference)).
 - Conservative default limits, runtime-tunable.
 
 ## Install

--- a/src/multipartkit/infer.gleam
+++ b/src/multipartkit/infer.gleam
@@ -65,16 +65,57 @@ fn noop_bytes(_body: BitArray) -> Option(String) {
 
 /// Optional content-type inference from a filename.
 ///
-/// The default v0.1.0 implementation always returns `None`. Wire `mimetype`
-/// (or another inferer) in via `form.add_file_auto_with` to enable
-/// inference.
+/// This is the default no-op of multipartkit's pluggable inference
+/// interface: it **always returns `None`** for every input, including
+/// well-known extensions like `"photo.png"` or `"doc.pdf"`. multipartkit
+/// deliberately ships no built-in extension table so the library has zero
+/// inference dependencies; callers who want real inference wire one in via
+/// `form.add_file_auto_with` (the function this helper exists to compose
+/// with). Calling this function directly is rarely what you want — it
+/// exists mainly so the `Inferer` shape stays uniform whether or not a
+/// real inferer is wired in.
+///
+/// To get actual inference, build an `Inferer` from `nao1215/mimetype`
+/// (or any other inference library) and pass it to
+/// `form.add_file_auto_with`:
+///
+/// ```gleam
+/// import gleam/option.{type Option, None, Some}
+/// import mimetype
+/// import multipartkit/form
+/// import multipartkit/infer.{type Inferer, Inferer}
+///
+/// let inferer =
+///   Inferer(
+///     from_filename: fn(name) {
+///       case mimetype.filename_to_mime_type_strict(name) {
+///         Ok(value) -> Some(value)
+///         Error(_) -> None
+///       }
+///     },
+///     from_bytes: fn(body) {
+///       case mimetype.detect_strict(body) {
+///         Ok(value) -> Some(value)
+///         Error(_) -> None
+///       }
+///     },
+///   )
+/// form.add_file_auto_with(my_form, "upload", "photo.png", bytes, inferer)
+/// ```
+///
+/// See also `examples/mimetype_inference` for a runnable wiring.
 pub fn content_type_from_filename(filename: String) -> Option(String) {
   default_inferer().from_filename(filename)
 }
 
 /// Optional content-type inference from a body byte sequence.
 ///
-/// Same default-`None` policy as `content_type_from_filename`.
+/// Same documented default-no-op policy as `content_type_from_filename`:
+/// this **always returns `None`** for every input, including well-known
+/// magic-byte signatures like the 8-byte PNG header. Wire `nao1215/mimetype`
+/// (or another inferer) in via `form.add_file_auto_with` for actual
+/// inference — see the docstring on `content_type_from_filename` for a
+/// worked example.
 pub fn content_type_from_bytes(body: BitArray) -> Option(String) {
   default_inferer().from_bytes(body)
 }

--- a/test/regression_infer_default_test.gleam
+++ b/test/regression_infer_default_test.gleam
@@ -1,0 +1,74 @@
+//// Regression tests for Issue #52: `multipartkit/infer.content_type_from_filename`
+//// and `content_type_from_bytes` are documented **default no-ops** of the
+//// pluggable inference interface — they always return `None` for every
+//// input, including well-known extensions and magic-byte signatures.
+////
+//// These tests pin the no-op behaviour so a future implementation change
+//// (e.g. wiring in `nao1215/mimetype` at the top level) cannot ship
+//// silently against the documented contract called out in `infer.gleam`
+//// and `README.md`.
+
+import gleam/option.{None}
+import gleeunit/should
+import multipartkit/infer
+
+// === Documented no-op: filename-based inference always returns None ===
+
+pub fn infer_default_returns_none_test() {
+  // The two assertions from Issue #52: known extension and known magic
+  // bytes both fall through to `None`.
+  infer.content_type_from_filename("photo.png") |> should.equal(None)
+  infer.content_type_from_bytes(<<137, 80, 78, 71>>) |> should.equal(None)
+}
+
+pub fn infer_default_filename_pdf_returns_none_test() {
+  infer.content_type_from_filename("doc.pdf") |> should.equal(None)
+}
+
+pub fn infer_default_filename_js_returns_none_test() {
+  infer.content_type_from_filename("script.js") |> should.equal(None)
+}
+
+pub fn infer_default_filename_html_returns_none_test() {
+  infer.content_type_from_filename("page.html") |> should.equal(None)
+}
+
+pub fn infer_default_filename_empty_returns_none_test() {
+  infer.content_type_from_filename("") |> should.equal(None)
+}
+
+// === Documented no-op: byte-based inference always returns None ===
+
+pub fn infer_default_bytes_full_png_signature_returns_none_test() {
+  // Full 8-byte PNG signature: still None under the default no-op.
+  infer.content_type_from_bytes(<<137, 80, 78, 71, 13, 10, 26, 10>>)
+  |> should.equal(None)
+}
+
+pub fn infer_default_bytes_jpeg_signature_returns_none_test() {
+  // JPEG SOI marker (FFD8FF) — still None.
+  infer.content_type_from_bytes(<<0xFF, 0xD8, 0xFF>>) |> should.equal(None)
+}
+
+pub fn infer_default_bytes_pdf_signature_returns_none_test() {
+  // "%PDF-" — still None.
+  infer.content_type_from_bytes(<<0x25, 0x50, 0x44, 0x46, 0x2D>>)
+  |> should.equal(None)
+}
+
+pub fn infer_default_bytes_empty_returns_none_test() {
+  infer.content_type_from_bytes(<<>>) |> should.equal(None)
+}
+
+// === `default_inferer()` exposes the same no-op behaviour ===
+
+pub fn infer_default_inferer_from_filename_returns_none_test() {
+  let inferer = infer.default_inferer()
+  inferer.from_filename("photo.png") |> should.equal(None)
+}
+
+pub fn infer_default_inferer_from_bytes_returns_none_test() {
+  let inferer = infer.default_inferer()
+  inferer.from_bytes(<<137, 80, 78, 71, 13, 10, 26, 10>>)
+  |> should.equal(None)
+}


### PR DESCRIPTION
## Summary

`multipartkit/infer.content_type_from_filename` and `content_type_from_bytes` are documented default no-ops of the pluggable inference interface — they always return `None`, even for well-known extensions like `photo.png` or magic-byte signatures like the PNG header. The original docstrings under-sold this contract, so a caller could reasonably expect built-in sniffing and silently get `None`. This PR clarifies the contract in the docstring, in the README, and pins the behaviour with regression tests, without touching the runtime behaviour.

## Changes

- `src/multipartkit/infer.gleam`: expand the docstrings on `content_type_from_filename` and `content_type_from_bytes` to state that both helpers always return `None` for every input, explain that multipartkit deliberately ships no built-in inference, and show a worked example of wiring `nao1215/mimetype` into `form.add_file_auto_with`. Cross-reference `examples/mimetype_inference`.
- `README.md`: extend the "Pluggable content-type inference" bullet so the top-level helpers' default-`None` policy is visible from the front door, and link the runnable example.
- `test/regression_infer_default_test.gleam`: new regression file pinning the no-op behaviour for `content_type_from_filename` (`.png`, `.pdf`, `.js`, `.html`, empty), for `content_type_from_bytes` (full PNG signature, JPEG SOI, `%PDF-`, empty), and for `default_inferer()` direct calls. Includes the exact `infer_default_returns_none_test` from the issue.
- `CHANGELOG.md`: new `### Documentation` entry under `## [Unreleased]` recording the doc clarification (#52).

## Design Decisions

Adopted issue option A (docstring + README clarification, no behavioural change). Option B (bundle `nao1215/mimetype` as a default inferer) was rejected because it would add a runtime dependency for what multipartkit explicitly designs as a pluggable seam, and it would couple `multipartkit` to one specific mime-detection library. Option C (delete the helpers) was rejected because the `Inferer` shape itself is part of the public surface and keeping symmetric top-level accessors is more discoverable than removing them; the doc clarification is sufficient to remove the silent-`None` foot-gun. The runtime code is intentionally untouched so existing callers see no behaviour change.

Closes #52