### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-20
+
 ### Documentation
 
 - `multipartkit/infer.content_type_from_filename` and `content_type_from_bytes` docstrings, and the README "Pluggable content-type inference" bullet, now state explicitly that these top-level helpers are **default no-ops** of the pluggable inference interface and always return `None`; callers wanting real inference must wire an `Inferer` (e.g. backed by `nao1215/mimetype`) into `form.add_file_auto_with`. (#52)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.12.0"
+version = "0.13.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Documentation

- `multipartkit/infer.content_type_from_filename` and `content_type_from_bytes` docstrings, and the README "Pluggable content-type inference" bullet, now state explicitly that these top-level helpers are **default no-ops** of the pluggable inference interface and always return `None`; callers wanting real inference must wire an `Inferer` (e.g. backed by `nao1215/mimetype`) into `form.add_file_auto_with`. (#52)

### Added

- `multipartkit/form.add_field_strict` and `add_file_strict` now reject empty or whitespace-only `name` with the new `Error(EmptyFieldName(value:))` variant, aligning with RFC 7578 §4.2 which requires the `Content-Disposition` `name` parameter to be the field name; the non-strict `add_field` / `add_file` keep their existing silent-accept behaviour for backward compatibility. (#51)

### Changed

- `multipartkit/content_disposition.parse` now enforces RFC 7230 §3.2.6 `quoted-pair` strictly: a `\X` whose `X` is outside `HTAB / SP / VCHAR / obs-text` (for example `NUL`, `CR`, `LF`, or any other ASCII control byte) is rejected with the new `Error(InvalidQuotedPair(_))` instead of silently dropping the backslash, blocking `NUL`-smuggling into the decoded `name` / `filename`. (#50)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.13.0 (2026-05-20)

* **New Features**
  * Added strict form-builder variants with enhanced validation that rejects empty and whitespace-only field names.

* **Bug Fixes**
  * Improved RFC 7230 compliance by enforcing stricter validation of quoted-pair sequences in content disposition parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/multipartkit/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->