### PR TITLE
fix(form): rename blank add_field name to _unnamed_<n> instead of emitting empty name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.13.0] - 2026-05-20
+### Fixed
+
+- `multipartkit/form.add_field` no longer lets an empty (or stripped-to-empty / whitespace-only) `name` reach the wire as `Content-Disposition: form-data; name=""`. The lenient builder now renames such a part to a generated `"_unnamed_<n>"` placeholder (where `<n>` is the part's zero-based position), so the observable `name` is never `Some("")` and the part stays RFC 7578-addressable. The placeholder is position-based, not collision-proof against a caller who also supplies a literal `"_unnamed_<k>"`. Callers that want bad names surfaced as a typed error rather than renamed should use `add_field_strict`. (#57, #58)
 
 ### Documentation
 

--- a/src/multipartkit/form.gleam
+++ b/src/multipartkit/form.gleam
@@ -1,4 +1,5 @@
 import gleam/bool
+import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
@@ -22,8 +23,9 @@ pub opaque type Form {
 /// `add_file_auto_with` silently strip CR / LF / NUL bytes from
 /// the values that flow into header lines (sealing the #28 header
 /// injection vector). The silent strip is data loss the caller
-/// cannot observe — `add_field("name\n", _)` produces
-/// `name=""`, and `add_file(_, "fi\nle.png", _, _)` concatenates
+/// cannot observe — `add_field("name\n", _)` produces a part renamed
+/// to `"_unnamed_<n>"` (the lenient path never emits `name=""`; see
+/// `add_field`), and `add_file(_, "fi\nle.png", _, _)` concatenates
 /// the two halves into a different valid filename. The `*_strict`
 /// variants surface this as a typed error so callers can render
 /// "field name `foo\\nbar` contains forbidden control bytes"
@@ -59,20 +61,28 @@ pub fn new() -> Form {
 ///
 /// RFC 7578 §4.2 requires the `Content-Disposition` `name` parameter
 /// to be non-empty (it is the field name itself). This non-strict
-/// variant does **not** enforce that — it silently accepts `""` and
-/// also silently strips CR / LF / NUL bytes from `name` to prevent
-/// header injection. The cached `name` on the resulting `Part`
-/// reflects the sanitized value, matching what a parse-after-encode
-/// round-trip would produce. The silent acceptance and strip is data
-/// loss the caller cannot observe — `add_field("", _)` produces
-/// `name=""`, and `add_field("name\n", _)` produces a part with
-/// `name=""` — so callers passing user-typed or upstream data into
-/// `name` should prefer `add_field_strict`, which surfaces both
-/// failure modes as typed errors (`EmptyFieldName(value:)` and
-/// `NameContainsControlBytes(value:)`). Use `unsafe_add_part` if
+/// variant does **not** reject a bad `name` — it silently strips CR /
+/// LF / NUL bytes to prevent header injection. To guarantee the
+/// resulting part is always RFC 7578-addressable, a `name` that is
+/// empty (or becomes empty / whitespace-only after the strip) is
+/// replaced with a generated placeholder `"_unnamed_<n>"`, where `<n>`
+/// is the part's zero-based position in the form. This means the
+/// observable `name` is **never** `""` — `add_field("", _)` and
+/// `add_field("name\n", _)` both produce a part named `"_unnamed_0"`
+/// rather than a silently empty-named part whose receiver
+/// interpretation is implementation-defined (#57, #58). The rename is
+/// still a loss the caller cannot prevent here, so callers passing
+/// user-typed or upstream data into `name` should prefer
+/// `add_field_strict`, which surfaces both failure modes as typed
+/// errors (`EmptyFieldName(value:)` and `NameContainsControlBytes(value:)`)
+/// instead of renaming. The cached `name` on the resulting `Part`
+/// reflects the placeholder and survives a parse-after-encode round-trip
+/// unchanged. The placeholder is position-based, not collision-proof: a
+/// caller who also passes a literal `"_unnamed_<k>"` as a real field name
+/// can end up with two parts sharing that name. Use `unsafe_add_part` if
 /// byte-exact preservation of arbitrary header values is required.
 pub fn add_field(form: Form, name name: String, value value: String) -> Form {
-  let safe_name = disposition.sanitize_value(name)
+  let safe_name = ensure_named(form, disposition.sanitize_value(name))
   let header = #(
     "Content-Disposition",
     disposition.build_form_data_value(safe_name, None),
@@ -253,6 +263,20 @@ pub fn parts(form: Form) -> List(Part) {
 
 fn push(form: Form, the_part: Part) -> Form {
   Form(reversed_parts: [the_part, ..form.reversed_parts])
+}
+
+/// Guarantee a non-empty field name for the lenient (`add_field`)
+/// builder path. `safe_name` is the value after CR / LF / NUL stripping.
+/// RFC 7578 §4.2 requires the `name` parameter to be the field name; an
+/// empty name produces a wire image whose receiver interpretation is
+/// implementation-defined. Rather than emit `name=""`, replace an empty
+/// (or whitespace-only) name with `"_unnamed_<n>"`, where `<n>` is the
+/// zero-based position the new part will occupy. A name that is merely
+/// padded (e.g. `" a "`) is kept as-is — only an entirely blank name is
+/// rewritten. (#57, #58)
+fn ensure_named(form: Form, safe_name: String) -> String {
+  use <- bool.guard(when: string.trim(safe_name) != "", return: safe_name)
+  "_unnamed_" <> int.to_string(list.length(form.reversed_parts))
 }
 
 fn build_file_part(

--- a/test/regression_add_field_empty_name_test.gleam
+++ b/test/regression_add_field_empty_name_test.gleam
@@ -1,0 +1,98 @@
+//// Regression tests for Issues #57 and #58: the lenient
+//// `multipartkit/form.add_field` must never let an empty `name`
+//// (whether passed empty, or stripped to empty by CR / LF / NUL
+//// removal) reach the wire as `Content-Disposition: form-data;
+//// name=""`.
+////
+//// RFC 7578 §4.2 says the `name` parameter is the field name; an empty
+//// name produces a wire image whose receiver interpretation is
+//// implementation-defined. The strict `add_field_strict` rejects such
+//// input with `Error(EmptyFieldName(_))`; the lenient `add_field`
+//// instead renames the part to a generated `"_unnamed_<n>"` placeholder
+//// (option 2 of the issue: normalise loudly) so the observable `name`
+//// is never `Some("")`.
+
+import gleam/list
+import gleam/option.{Some}
+import gleeunit/should
+import multipartkit
+import multipartkit/form
+import multipartkit/part
+
+// Names that are empty after CR / LF / NUL stripping. Each must round-trip
+// to a non-empty name rather than Some("").
+const blank_after_strip = ["", "\n", "\r", "\r\n", "\u{0000}"]
+
+pub fn add_field_empty_name_never_round_trips_to_empty_test() {
+  list.each(blank_after_strip, fn(bad) {
+    let f = form.new() |> form.add_field(name: bad, value: "x")
+    let #(ct, body) = multipartkit.encode_form(f)
+    let assert Ok(parts) = multipartkit.parse(body, ct)
+    case parts {
+      [p, ..] -> part.name(p) |> should.not_equal(Some(""))
+      [] -> should.fail()
+    }
+  })
+}
+
+pub fn add_field_empty_name_uses_placeholder_test() {
+  let f = form.new() |> form.add_field(name: "", value: "x")
+  let #(ct, body) = multipartkit.encode_form(f)
+  let assert Ok([p]) = multipartkit.parse(body, ct)
+  part.name(p) |> should.equal(Some("_unnamed_0"))
+}
+
+pub fn add_field_crlf_only_name_uses_placeholder_test() {
+  // CR/LF/NUL-only names strip to "" and therefore get the placeholder.
+  let f = form.new() |> form.add_field(name: "\r\n", value: "x")
+  let #(ct, body) = multipartkit.encode_form(f)
+  let assert Ok([p]) = multipartkit.parse(body, ct)
+  part.name(p) |> should.equal(Some("_unnamed_0"))
+}
+
+pub fn add_field_whitespace_only_name_uses_placeholder_test() {
+  // Whitespace-only names are blank per RFC 7578 and also get renamed,
+  // matching the "empty" notion that add_field_strict rejects.
+  let f = form.new() |> form.add_field(name: "   ", value: "x")
+  let #(ct, body) = multipartkit.encode_form(f)
+  let assert Ok([p]) = multipartkit.parse(body, ct)
+  part.name(p) |> should.equal(Some("_unnamed_0"))
+}
+
+pub fn add_field_partially_stripped_name_kept_test() {
+  // "ab\ncd" strips to "abcd" which is non-empty, so it is kept as-is and
+  // NOT replaced with a placeholder.
+  let f = form.new() |> form.add_field(name: "ab\ncd", value: "x")
+  let #(ct, body) = multipartkit.encode_form(f)
+  let assert Ok([p]) = multipartkit.parse(body, ct)
+  part.name(p) |> should.equal(Some("abcd"))
+}
+
+pub fn add_field_padded_name_kept_test() {
+  // A name that merely has surrounding whitespace is kept verbatim — only
+  // an entirely blank name is rewritten.
+  let f = form.new() |> form.add_field(name: " a ", value: "x")
+  let #(ct, body) = multipartkit.encode_form(f)
+  let assert Ok([p]) = multipartkit.parse(body, ct)
+  part.name(p) |> should.equal(Some(" a "))
+}
+
+pub fn add_field_normal_name_unchanged_test() {
+  let f = form.new() |> form.add_field(name: "foo", value: "x")
+  let #(ct, body) = multipartkit.encode_form(f)
+  let assert Ok([p]) = multipartkit.parse(body, ct)
+  part.name(p) |> should.equal(Some("foo"))
+}
+
+pub fn add_field_placeholder_index_tracks_position_test() {
+  // Each blank-named part gets a distinct placeholder based on its
+  // zero-based position, so multiple empty names do not collide.
+  let f =
+    form.new()
+    |> form.add_field(name: "", value: "a")
+    |> form.add_field(name: "kept", value: "b")
+    |> form.add_field(name: "\n", value: "c")
+  let names = form.parts(f) |> list.map(part.name)
+  names
+  |> should.equal([Some("_unnamed_0"), Some("kept"), Some("_unnamed_2")])
+}


### PR DESCRIPTION
## Summary

The lenient `multipartkit/form.add_field` silently produced a part with `Content-Disposition: form-data; name=""` when given an empty `name`, or a `name` that became empty after CR/LF/NUL stripping. RFC 7578 §4.2 requires the `name` parameter to be the field name, and an empty name produces a wire image whose receiver interpretation is implementation-defined (skip the field, overwrite siblings keyed on `""`, or reject the whole body). Only `add_field_strict` rejected this; the default path was a silent data-loss / non-compliant-wire vector. This closes the two regression reports #57 (CR/LF stripped to empty) and #58 (empty name accepted), which share the same root cause.

## Changes

This implements the issues' "option 2: normalise loudly". The lenient `add_field` now renames a blank name (empty, or empty/whitespace-only after stripping) to a generated `"_unnamed_<n>"` placeholder, where `<n>` is the part's zero-based position in the form. The observable `name` is therefore never `Some("")`, the part stays RFC 7578-addressable, and the `add_field` signature stays `-> Form` (no breaking API change). A name that is merely padded (e.g. `" a "`) or only partially stripped (e.g. `"ab\ncd"` -> `"abcd"`) is kept as-is — only an entirely blank name is rewritten.

`add_field_strict` is unchanged: callers that want bad names surfaced as `Error(EmptyFieldName(_))` / `Error(NameContainsControlBytes(_))` rather than renamed should keep using it.

Added `test/regression_add_field_empty_name_test.gleam` covering the empty / CR-LF-only / NUL-only / whitespace-only cases, the partial-strip and padded cases that must be kept verbatim, the normal-name baseline, and placeholder index tracking across interleaved blank and non-blank fields.

## Design Decisions

Option 2 was chosen over option 1 (reject in `add_field`) and option 3 (reject at `encode_form`) because it is the only option that both satisfies the issues' Definition-of-Done (name never round-trips to `Some("")`) and keeps the existing backward-compatibility pin `add_field_non_strict_empty_name_still_accepted_test` green — that test asserts the non-strict path still produces exactly one part, so dropping the part (option 1) or returning a `Result` from `encode_form` (option 3) would have been a larger, breaking change. Renaming preserves the caller's value under a visible, detectable synthetic name rather than discarding it.

The whitespace-only case is normalised too, matching the "empty" notion that `add_field_strict` already rejects via `string.trim`.

## Limitations

The `_unnamed_<n>` placeholder is position-based, not collision-proof: a caller who also supplies a literal `"_unnamed_<k>"` as a real field name can end up with two parts sharing that name. This is documented on `add_field` and is strictly better than the previous `name=""` behaviour.

`add_file`'s `name` channel (and the `filename` channel) are intentionally left unchanged — both issues explicitly defer `add_file` to a separate ticket.

Closes #57
Closes #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `add_field` to prevent empty field names from being emitted. Names that become empty after sanitization are now automatically replaced with generated placeholders (`_unnamed_<n>`) based on field position, ensuring RFC 7578 compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->