### PR TITLE
feat(infer): resolve known content types via mimetype instead of no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `multipartkit/infer.content_type_from_filename` and `content_type_from_bytes` are no longer no-ops: they now resolve well-known extensions and magic-byte signatures by delegating to `nao1215/mimetype`, returning `Some(mime)` for recognised input (`"a.png"` -> `Some("image/png")`, a PNG header -> `Some("image/png")`) and `None` otherwise. `nao1215/mimetype` is added as a runtime dependency. A new `infer.builtin_inferer()` wires these helpers into an `Inferer` so `form.add_file_auto_with(form, ..., infer.builtin_inferer())` gets built-in inference; `infer.default_inferer()` is intentionally kept a no-op so `add_file_auto` still falls through to `application/octet-stream` and never changes a content type implicitly. This reverses the v0.13.0 (#52) decision to ship these helpers as documented no-ops. (#59)
+
 ### Fixed
 
 - `multipartkit/form.add_field` no longer lets an empty (or stripped-to-empty / whitespace-only) `name` reach the wire as `Content-Disposition: form-data; name=""`. The lenient builder now renames such a part to a generated `"_unnamed_<n>"` placeholder (where `<n>` is the part's zero-based position), so the observable `name` is never `Some("")` and the part stays RFC 7578-addressable. The placeholder is position-based, not collision-proof against a caller who also supplies a literal `"_unnamed_<k>"`. Callers that want bad names surfaced as a typed error rather than renamed should use `add_field_strict`. (#57, #58)
+
+## [0.13.0] - 2026-05-20
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ target: `multipart/form-data`. Secondary: `multipart/mixed` and
   parser with safe per-chunk `max_body_bytes` enforcement.
 - `Content-Disposition` parser including RFC 5987 / RFC 8187
   `filename*` (UTF-8 and ISO-8859-1).
-- Pluggable content-type inference — wire
-  [`nao1215/mimetype`](https://github.com/nao1215/mimetype) (or any
-  other inferer) without changing this library. The top-level
-  `multipartkit/infer.content_type_from_filename` and
-  `content_type_from_bytes` are documented **default no-ops** that
-  always return `None`; actual inference happens when an `Inferer` is
-  passed to `form.add_file_auto_with` (see
+- Built-in content-type inference — `multipartkit/infer.content_type_from_filename`
+  and `content_type_from_bytes` resolve well-known extensions and
+  magic-byte signatures (`"a.png"` -> `Some("image/png")`, a PNG header
+  -> `Some("image/png")`) by delegating to
+  [`nao1215/mimetype`](https://github.com/nao1215/mimetype), returning
+  `None` for unknown input. Inference into the form builder stays
+  opt-in: `add_file_auto` uses the no-op `default_inferer` (so it never
+  changes a content type implicitly), while
+  `add_file_auto_with(form, ..., infer.builtin_inferer())` opts into the
+  built-in inference, and a custom `Inferer` lets you wire any other
+  library (see
   [`examples/mimetype_inference`](examples/mimetype_inference)).
 - Conservative default limits, runtime-tunable.
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -12,6 +12,7 @@ gleam = ">= 1.15.0"
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_yielder = ">= 1.0.0 and < 2.0.0"
+mimetype = ">= 0.24.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -13,6 +13,7 @@ packages = [
   { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glinter", version = "2.15.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "551033723DD0044D296EC79B9A14CB782BCC197C17683E3EAD85F6A01C83548C" },
   { name = "metamon", version = "0.6.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "simplifile"], otp_app = "metamon", source = "hex", outer_checksum = "4F724E4AE5EE8DDADE8F6D186903C2CECA83D6E704BE452B1973CA9629A6DA49" },
+  { name = "mimetype", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "mimetype", source = "hex", outer_checksum = "3146886415ABC0796639DD574A71D180C0B628E15819627D2DC390ED678C16B8" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "tom", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "234A842F3D087D35737483F5DFB6DE9839E3366EF0CAF8726D2D094210227670" },
@@ -24,3 +25,4 @@ gleam_yielder = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.14.0 and < 3.0.0" }
 metamon = { version = ">= 0.6.0 and < 1.0.0" }
+mimetype = { version = ">= 0.24.0 and < 1.0.0" }

--- a/src/multipartkit/form.gleam
+++ b/src/multipartkit/form.gleam
@@ -133,8 +133,10 @@ pub fn add_file(
 ///
 /// Equivalent to `add_file_auto_with(form, name, filename, body,
 /// infer.default_inferer())`. The default inferer returns `None` from both
-/// helpers in v0.1.0, so this falls through to `application/octet-stream`
-/// unless you call `add_file_auto_with` with a real inferer.
+/// helpers, so this always falls through to `application/octet-stream` —
+/// inference is opt-in. To resolve well-known extensions and magic-byte
+/// signatures via `nao1215/mimetype`, call `add_file_auto_with` with
+/// `infer.builtin_inferer()` (or your own `Inferer`).
 pub fn add_file_auto(
   form: Form,
   name: String,

--- a/src/multipartkit/infer.gleam
+++ b/src/multipartkit/infer.gleam
@@ -1,4 +1,5 @@
 import gleam/option.{type Option, None}
+import mimetype
 
 /// A pair of content-type inferers that callers can wire into
 /// `form.add_file_auto_with`.
@@ -7,36 +8,21 @@ import gleam/option.{type Option, None}
 /// is tried next; if both return `None`, the host falls back to
 /// `application/octet-stream`.
 ///
-/// The default inferer returns `None` from both functions, so by default
-/// `add_file_auto` always falls through to `application/octet-stream`.
-/// Wire `nao1215/mimetype` (or any other inference library) by passing an
-/// `Inferer` to `form.add_file_auto_with`:
+/// Two ready-made inferers are provided: `default_inferer` (a no-op that
+/// always returns `None`, so `add_file_auto` falls through to
+/// `application/octet-stream`) and `builtin_inferer` (backed by the
+/// built-in `content_type_from_filename` / `content_type_from_bytes`,
+/// which resolve well-known extensions and magic-byte signatures via
+/// `nao1215/mimetype`). Pass whichever you want to
+/// `form.add_file_auto_with`, or supply your own:
 ///
 /// ```gleam
-/// import gleam/option.{type Option, None, Some}
-/// import mimetype
-/// import multipartkit/form.{type Form}
-/// import multipartkit/infer.{type Inferer, Inferer}
+/// import multipartkit/form
+/// import multipartkit/infer
 ///
-/// pub fn upload_with_mimetype(
-///   form_value: Form,
-///   filename: String,
-///   bytes: BitArray,
-/// ) -> Form {
-///   let from_filename = fn(name: String) -> Option(String) {
-///     case mimetype.filename_to_mime_type_strict(name) {
-///       Ok(value) -> Some(value)
-///       Error(_) -> None
-///     }
-///   }
-///   let from_bytes = fn(body: BitArray) -> Option(String) {
-///     case mimetype.detect_strict(body) {
-///       Ok(value) -> Some(value)
-///       Error(_) -> None
-///     }
-///   }
-///   let inferer = Inferer(from_filename: from_filename, from_bytes: from_bytes)
-///   form.add_file_auto_with(form_value, "upload", filename, bytes, inferer)
+/// pub fn upload(form_value, filename, bytes) {
+///   // Resolve image/png, application/pdf, etc. out of the box.
+///   form.add_file_auto_with(form_value, "upload", filename, bytes, infer.builtin_inferer())
 /// }
 /// ```
 pub type Inferer {
@@ -50,7 +36,10 @@ pub type Inferer {
 ///
 /// `add_file_auto` uses this and therefore always emits
 /// `application/octet-stream` unless the host swaps in a real inferer via
-/// `add_file_auto_with`.
+/// `add_file_auto_with` (for example `builtin_inferer`, or one of your
+/// own). Keeping the default a no-op means `add_file_auto` never changes
+/// the content type implicitly — inference is always something the caller
+/// opts into.
 pub fn default_inferer() -> Inferer {
   Inferer(from_filename: noop_filename, from_bytes: noop_bytes)
 }
@@ -63,59 +52,60 @@ fn noop_bytes(_body: BitArray) -> Option(String) {
   None
 }
 
-/// Optional content-type inference from a filename.
+/// Inferer backed by the built-in `content_type_from_filename` and
+/// `content_type_from_bytes` helpers (which delegate to
+/// `nao1215/mimetype`).
 ///
-/// This is the default no-op of multipartkit's pluggable inference
-/// interface: it **always returns `None`** for every input, including
-/// well-known extensions like `"photo.png"` or `"doc.pdf"`. multipartkit
-/// deliberately ships no built-in extension table so the library has zero
-/// inference dependencies; callers who want real inference wire one in via
-/// `form.add_file_auto_with` (the function this helper exists to compose
-/// with). Calling this function directly is rarely what you want — it
-/// exists mainly so the `Inferer` shape stays uniform whether or not a
-/// real inferer is wired in.
-///
-/// To get actual inference, build an `Inferer` from `nao1215/mimetype`
-/// (or any other inference library) and pass it to
-/// `form.add_file_auto_with`:
+/// Pass this to `form.add_file_auto_with` to get content-type inference
+/// for well-known extensions and magic-byte signatures without writing
+/// the `mimetype` wiring yourself:
 ///
 /// ```gleam
-/// import gleam/option.{type Option, None, Some}
-/// import mimetype
-/// import multipartkit/form
-/// import multipartkit/infer.{type Inferer, Inferer}
-///
-/// let inferer =
-///   Inferer(
-///     from_filename: fn(name) {
-///       case mimetype.filename_to_mime_type_strict(name) {
-///         Ok(value) -> Some(value)
-///         Error(_) -> None
-///       }
-///     },
-///     from_bytes: fn(body) {
-///       case mimetype.detect_strict(body) {
-///         Ok(value) -> Some(value)
-///         Error(_) -> None
-///       }
-///     },
-///   )
-/// form.add_file_auto_with(my_form, "upload", "photo.png", bytes, inferer)
+/// form.add_file_auto_with(my_form, "upload", "photo.png", bytes, infer.builtin_inferer())
+/// // -> the part's Content-Type is image/png
 /// ```
-///
-/// See also `examples/mimetype_inference` for a runnable wiring.
-pub fn content_type_from_filename(filename: String) -> Option(String) {
-  default_inferer().from_filename(filename)
+pub fn builtin_inferer() -> Inferer {
+  Inferer(
+    from_filename: content_type_from_filename,
+    from_bytes: content_type_from_bytes,
+  )
 }
 
-/// Optional content-type inference from a body byte sequence.
+/// Infer a content type from a filename's extension.
 ///
-/// Same documented default-no-op policy as `content_type_from_filename`:
-/// this **always returns `None`** for every input, including well-known
-/// magic-byte signatures like the 8-byte PNG header. Wire `nao1215/mimetype`
-/// (or another inferer) in via `form.add_file_auto_with` for actual
-/// inference — see the docstring on `content_type_from_filename` for a
-/// worked example.
+/// Delegates to `nao1215/mimetype`'s extension database: returns
+/// `Some(mime)` for a recognised extension (for example `"photo.png"` ->
+/// `Some("image/png")`, `"doc.pdf"` -> `Some("application/pdf")`,
+/// `"data.json"` -> `Some("application/json")`) and `None` when the path
+/// has no usable extension (`""`, `"README"`) or the extension is not in
+/// the database (`"a.zzznosuch"`).
+///
+/// This is a convenience over the `mimetype` dependency; for the form
+/// builder, wire it in with `form.add_file_auto_with(form, ...,
+/// builtin_inferer())` (or build your own `Inferer`).
+pub fn content_type_from_filename(filename: String) -> Option(String) {
+  mimetype.filename_to_mime_type_strict(filename)
+  |> option.from_result
+  |> option.map(mimetype.essence_of)
+}
+
+/// Infer a content type from a body's leading bytes (magic-number
+/// signature).
+///
+/// Delegates to `nao1215/mimetype`'s detector: returns `Some(mime)` for a
+/// recognised signature (for example the 8-byte PNG header ->
+/// `Some("image/png")`, `<<0xFF, 0xD8, 0xFF, ...>>` ->
+/// `Some("image/jpeg")`, `"%PDF-..."` -> `Some("application/pdf")`) and
+/// `None` for the empty `BitArray` or input whose bytes match no
+/// supported signature. Note `mimetype`'s detector classifies arbitrary
+/// printable-ASCII input as `Some("text/plain")`, so a text body with no
+/// stronger signature resolves to `text/plain` rather than `None`.
+///
+/// As with `content_type_from_filename`, this is a convenience over the
+/// `mimetype` dependency; wire it into the form builder with
+/// `form.add_file_auto_with(form, ..., builtin_inferer())`.
 pub fn content_type_from_bytes(body: BitArray) -> Option(String) {
-  default_inferer().from_bytes(body)
+  mimetype.detect_strict(body)
+  |> option.from_result
+  |> option.map(mimetype.essence_of)
 }

--- a/test/regression_infer_default_test.gleam
+++ b/test/regression_infer_default_test.gleam
@@ -1,74 +1,92 @@
-//// Regression tests for Issue #52: `multipartkit/infer.content_type_from_filename`
-//// and `content_type_from_bytes` are documented **default no-ops** of the
-//// pluggable inference interface — they always return `None` for every
-//// input, including well-known extensions and magic-byte signatures.
+//// Regression tests for Issue #59: `multipartkit/infer.content_type_from_filename`
+//// and `content_type_from_bytes` must resolve well-known types instead of
+//// always returning `None`.
 ////
-//// These tests pin the no-op behaviour so a future implementation change
-//// (e.g. wiring in `nao1215/mimetype` at the top level) cannot ship
-//// silently against the documented contract called out in `infer.gleam`
-//// and `README.md`.
+//// These helpers now delegate to `nao1215/mimetype`: they return
+//// `Some(mime)` for a recognised extension / magic-byte signature and
+//// `None` for unknown input. This supersedes the earlier #52 contract that
+//// pinned them as default no-ops.
+////
+//// `default_inferer()` is intentionally still a no-op (inference into the
+//// form builder is opt-in via `builtin_inferer()` / `add_file_auto_with`),
+//// so its behaviour is pinned separately below.
 
-import gleam/option.{None}
+import gleam/list
+import gleam/option.{None, Some}
 import gleeunit/should
 import multipartkit/infer
 
-// === Documented no-op: filename-based inference always returns None ===
+// === content_type_from_filename: known extensions resolve (#59 DoD) ===
 
-pub fn infer_default_returns_none_test() {
-  // The two assertions from Issue #52: known extension and known magic
-  // bytes both fall through to `None`.
-  infer.content_type_from_filename("photo.png") |> should.equal(None)
-  infer.content_type_from_bytes(<<137, 80, 78, 71>>) |> should.equal(None)
+pub fn content_type_from_filename_returns_known_test() {
+  let cases = [
+    #("a.png", "image/png"),
+    #("a.jpg", "image/jpeg"),
+    #("a.jpeg", "image/jpeg"),
+    #("a.gif", "image/gif"),
+    #("a.pdf", "application/pdf"),
+    #("a.json", "application/json"),
+    #("a.txt", "text/plain"),
+    #("a.csv", "text/csv"),
+    #("a.html", "text/html"),
+  ]
+  list.each(cases, fn(c) {
+    let #(name, expected) = c
+    infer.content_type_from_filename(name) |> should.equal(Some(expected))
+  })
 }
 
-pub fn infer_default_filename_pdf_returns_none_test() {
-  infer.content_type_from_filename("doc.pdf") |> should.equal(None)
-}
-
-pub fn infer_default_filename_js_returns_none_test() {
-  infer.content_type_from_filename("script.js") |> should.equal(None)
-}
-
-pub fn infer_default_filename_html_returns_none_test() {
-  infer.content_type_from_filename("page.html") |> should.equal(None)
-}
-
-pub fn infer_default_filename_empty_returns_none_test() {
+pub fn content_type_from_filename_unknown_test() {
+  infer.content_type_from_filename("a.zzznosuch") |> should.equal(None)
   infer.content_type_from_filename("") |> should.equal(None)
 }
 
-// === Documented no-op: byte-based inference always returns None ===
+// === content_type_from_bytes: magic-byte signatures resolve (#59 DoD) ===
 
-pub fn infer_default_bytes_full_png_signature_returns_none_test() {
-  // Full 8-byte PNG signature: still None under the default no-op.
-  infer.content_type_from_bytes(<<137, 80, 78, 71, 13, 10, 26, 10>>)
-  |> should.equal(None)
+pub fn content_type_from_bytes_magic_test() {
+  // PNG signature
+  let png = <<0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a>>
+  infer.content_type_from_bytes(png) |> should.equal(Some("image/png"))
+
+  // JPEG SOI + APP0
+  let jpeg = <<0xff, 0xd8, 0xff, 0xe0>>
+  infer.content_type_from_bytes(jpeg) |> should.equal(Some("image/jpeg"))
+
+  // PDF
+  let pdf = <<"%PDF-1.4":utf8>>
+  infer.content_type_from_bytes(pdf) |> should.equal(Some("application/pdf"))
+
+  // GIF87a
+  let gif = <<"GIF87a":utf8>>
+  infer.content_type_from_bytes(gif) |> should.equal(Some("image/gif"))
 }
 
-pub fn infer_default_bytes_jpeg_signature_returns_none_test() {
-  // JPEG SOI marker (FFD8FF) — still None.
-  infer.content_type_from_bytes(<<0xFF, 0xD8, 0xFF>>) |> should.equal(None)
-}
-
-pub fn infer_default_bytes_pdf_signature_returns_none_test() {
-  // "%PDF-" — still None.
-  infer.content_type_from_bytes(<<0x25, 0x50, 0x44, 0x46, 0x2D>>)
-  |> should.equal(None)
-}
-
-pub fn infer_default_bytes_empty_returns_none_test() {
+pub fn content_type_from_bytes_empty_returns_none_test() {
   infer.content_type_from_bytes(<<>>) |> should.equal(None)
 }
 
-// === `default_inferer()` exposes the same no-op behaviour ===
+// === default_inferer() stays a no-op (form-builder inference is opt-in) ===
 
-pub fn infer_default_inferer_from_filename_returns_none_test() {
+pub fn default_inferer_from_filename_still_none_test() {
   let inferer = infer.default_inferer()
   inferer.from_filename("photo.png") |> should.equal(None)
 }
 
-pub fn infer_default_inferer_from_bytes_returns_none_test() {
+pub fn default_inferer_from_bytes_still_none_test() {
   let inferer = infer.default_inferer()
   inferer.from_bytes(<<137, 80, 78, 71, 13, 10, 26, 10>>)
   |> should.equal(None)
+}
+
+// === builtin_inferer() exposes the mimetype-backed inference ===
+
+pub fn builtin_inferer_from_filename_resolves_test() {
+  let inferer = infer.builtin_inferer()
+  inferer.from_filename("photo.png") |> should.equal(Some("image/png"))
+}
+
+pub fn builtin_inferer_from_bytes_resolves_test() {
+  let inferer = infer.builtin_inferer()
+  inferer.from_bytes(<<137, 80, 78, 71, 13, 10, 26, 10>>)
+  |> should.equal(Some("image/png"))
 }


### PR DESCRIPTION
## Summary

`multipartkit/infer.content_type_from_filename` and `content_type_from_bytes` were default no-ops that returned `None` for every input, including well-known types (`"a.png"`, the PNG magic header, etc.). This made the public `infer` helpers surprising: a caller asking for the content type of `photo.png` got `None`. Issue #59 asks for real inference; the chosen resolution (option 1) is to delegate to the sibling `nao1215/mimetype` package, which already maintains the IANA + magic-byte tables.

This reverses the v0.13.0 (#52) decision to ship these helpers as documented no-ops. That decision was pinned by `test/regression_infer_default_test.gleam`; this PR rewrites that file to assert the new contract.

## Changes

`content_type_from_filename` and `content_type_from_bytes` now delegate to `mimetype.filename_to_mime_type_strict` / `mimetype.detect_strict`, returning `Some(mimetype.essence_of(_))` for recognised input and `None` otherwise (`option.from_result |> option.map(essence_of)`). `nao1215/mimetype` is added as a runtime dependency (`>= 0.24.0 and < 1.0.0`).

Inference into the form builder stays opt-in. `infer.default_inferer()` is intentionally kept a no-op, so `add_file_auto` still falls through to `application/octet-stream` and never changes a content type implicitly. A new `infer.builtin_inferer()` wires the two helpers into an `Inferer`, so callers can opt in with `form.add_file_auto_with(form, ..., infer.builtin_inferer())` without writing the `mimetype` wiring themselves.

`test/regression_infer_default_test.gleam` is rewritten to assert: the #59 DoD (known extensions and magic-byte signatures resolve to the expected MIME strings; unknown / empty input is `None`), that `default_inferer()` is still a no-op, and that `builtin_inferer()` resolves.

Docstrings, the README feature bullet, and the CHANGELOG are updated.

## Design Decisions

Option 1 (delegate to `mimetype`) was chosen over option 2 (inline a built-in table) because an inline table would duplicate, and inevitably drift from, the table that the sibling `mimetype` package already maintains — the very duplication the `infer` docstrings already steered callers away from. Delegating gives full IANA + magic-byte coverage with no duplicate maintenance.

`default_inferer()` is deliberately left a no-op rather than wired to `mimetype`, so `add_file_auto`'s behaviour is unchanged and inference remains an explicit opt-in (`builtin_inferer()` or a custom `Inferer`). This keeps the form builder from silently changing content types when the dependency resolves an extension.

## Notes

This PR also restores the `## [0.13.0] - 2026-05-20` CHANGELOG header, which was accidentally dropped in #60 — without it, the released 0.13.0 entries (#52, #51, #50) were sitting under `[Unreleased]`.

`mimetype.detect_strict` classifies arbitrary printable-ASCII input as `text/plain`; this is reachable only through the direct helper / `builtin_inferer` (never through `add_file_auto`), and is documented on `content_type_from_bytes`.

Closes #59
