### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-31
+
 ### Changed
 
 - `multipartkit/infer.content_type_from_filename` and `content_type_from_bytes` are no longer no-ops: they now resolve well-known extensions and magic-byte signatures by delegating to `nao1215/mimetype`, returning `Some(mime)` for recognised input (`"a.png"` -> `Some("image/png")`, a PNG header -> `Some("image/png")`) and `None` otherwise. `nao1215/mimetype` is added as a runtime dependency. A new `infer.builtin_inferer()` wires these helpers into an `Inferer` so `form.add_file_auto_with(form, ..., infer.builtin_inferer())` gets built-in inference; `infer.default_inferer()` is intentionally kept a no-op so `add_file_auto` still falls through to `application/octet-stream` and never changes a content type implicitly. This reverses the v0.13.0 (#52) decision to ship these helpers as documented no-ops. (#59)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipartkit"
-version = "0.13.0"
+version = "0.14.0"
 description = "Multipart body parsing and generation primitives for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "multipartkit" }


### PR DESCRIPTION
### Changed

- `multipartkit/infer.content_type_from_filename` and `content_type_from_bytes` are no longer no-ops: they now resolve well-known extensions and magic-byte signatures by delegating to `nao1215/mimetype`, returning `Some(mime)` for recognised input (`"a.png"` -> `Some("image/png")`, a PNG header -> `Some("image/png")`) and `None` otherwise. `nao1215/mimetype` is added as a runtime dependency. A new `infer.builtin_inferer()` wires these helpers into an `Inferer` so `form.add_file_auto_with(form, ..., infer.builtin_inferer())` gets built-in inference; `infer.default_inferer()` is intentionally kept a no-op so `add_file_auto` still falls through to `application/octet-stream` and never changes a content type implicitly. This reverses the v0.13.0 (#52) decision to ship these helpers as documented no-ops. (#59)

### Fixed

- `multipartkit/form.add_field` no longer lets an empty (or stripped-to-empty / whitespace-only) `name` reach the wire as `Content-Disposition: form-data; name=""`. The lenient builder now renames such a part to a generated `"_unnamed_<n>"` placeholder (where `<n>` is the part's zero-based position), so the observable `name` is never `Some("")` and the part stays RFC 7578-addressable. The placeholder is position-based, not collision-proof against a caller who also supplies a literal `"_unnamed_<k>"`. Callers that want bad names surfaced as a typed error rather than renamed should use `add_field_strict`. (#57, #58)
